### PR TITLE
Fix: Correct rsync path in deployment workflow

### DIFF
--- a/.github/workflows/deploy-backend-api.yml
+++ b/.github/workflows/deploy-backend-api.yml
@@ -23,12 +23,9 @@ jobs:
       - name: Show backend directory structure (for debug)
         run: ls -lR ./backend
 
-      - name: Rsync backend/api and backend/utils/ to serv00
+      - name: Rsync backend/api to serv00
         run: |
           rsync -avz --delete \
             --exclude='config.php' \
             -e "ssh -o StrictHostKeyChecking=no" \
             ./backend/api/ "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}:${{ secrets.SERV00_PATH }}/api/"
-          rsync -avz --delete \
-            -e "ssh -o StrictHostKeyChecking=no" \
-            ./backend/utils/ "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}:${{ secrets.SERV00_PATH }}/utils/"


### PR DESCRIPTION
The deployment workflow was failing because it tried to sync a non-existent directory (backend/utils/). This directory was removed when all backend files were consolidated into backend/api/.

This commit removes the incorrect rsync command, leaving only the correct one that deploys the backend/api/ directory. This should resolve the synchronization failure.