### PR TITLE
Fix: Correct typo in backend deployment workflow

### DIFF
--- a/.github/workflows/deploy-backend-api.yml
+++ b/.github/workflows/deploy-backend-api.yml
@@ -40,7 +40,7 @@ jobs:
             echo -e '\n目标目录状态:';
             ls -ld \"${{ secrets.SERV00_PATH }}\" || echo '目录不存在';
             echo -e '\n上级目录权限:';
-            ls -ld \"$(dirname \"${{ secrets.SVO0_PATH }}\")\" || echo '上级目录不存在';
+            ls -ld \"$(dirname \"${{ secrets.SERV00_PATH }}\")\" || echo '上级目录不存在';
             echo -e '\n磁盘使用情况:';
             df -h . | head -2
           "


### PR DESCRIPTION
Fix a typo in the `deploy-backend-api.yml` file where `secrets.SERV00_PATH` was incorrectly written as `secrets.SVO0_PATH`.