### PR TITLE
Fix(deploy): Ensure destination subdirectory exists

### DIFF
--- a/.github/workflows/deploy-backend-api.yml
+++ b/.github/workflows/deploy-backend-api.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Ensure remote directory exists
         run: |
           ssh -o BatchMode=yes "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}" "
-            mkdir -p \"${{ secrets.SERV00_PATH }}\"
+            mkdir -p \"${{ secrets.SERV00_PATH }}/api\"
             echo '目录创建成功或已存在'
           "
 


### PR DESCRIPTION
Updates the `deploy-backend-api.yml` workflow to create the `.../api` subdirectory on the remote server before running `rsync`. This fixes the 'No such file or directory' error that occurs when the parent directory exists but the immediate destination directory does not.