### PR TITLE
fix(deploy): add --mkpath to rsync command

### DIFF
--- a/.github/workflows/deploy-backend-api.yml
+++ b/.github/workflows/deploy-backend-api.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: Rsync backend/api to serv00
         run: |
-          rsync -avz --delete -e "ssh -o StrictHostKeyChecking=no" ./backend/api/ "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}:${{ secrets.SERV00_PATH }}/api/"
+          rsync -avz --mkpath --delete -e "ssh -o StrictHostKeyChecking=no" ./backend/api/ "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}:${{ secrets.SERV00_PATH }}/api/"


### PR DESCRIPTION
The rsync command in the deploy-backend-api.yml workflow was failing because the destination directory did not exist on the remote server.

This commit adds the --mkpath option to the rsync command, which will create the full destination path if it doesn't exist, resolving the deployment failure.