### PR TITLE
feat: Implement matchmaking and game modes

### DIFF
--- a/backend/api/api.php
+++ b/backend/api/api.php
@@ -40,15 +40,11 @@ if ($request_method === 'POST') {
             $password = $data['password'] ?? null;
             if (!$phone || !$password) send_json_error(400, '手机号和密码不能为空');
             if (strlen($password) < 6) send_json_error(400, '密码长度不能少于6位');
-
             $stmt = $db->prepare("SELECT id FROM users WHERE phone_number = ?");
             $stmt->bind_param('s', $phone);
             $stmt->execute();
             if ($stmt->get_result()->num_rows > 0) send_json_error(409, '该手机号已被注册');
-
             $password_hash = password_hash($password, PASSWORD_DEFAULT);
-
-            // Generate unique 4-digit ID
             $display_id = null;
             do {
                 $display_id = str_pad(rand(0, 9999), 4, '0', STR_PAD_LEFT);
@@ -56,7 +52,6 @@ if ($request_method === 'POST') {
                 $stmt->bind_param('s', $display_id);
                 $stmt->execute();
             } while ($stmt->get_result()->num_rows > 0);
-
             $stmt = $db->prepare("INSERT INTO users (display_id, phone_number, password_hash) VALUES (?, ?, ?)");
             $stmt->bind_param('sss', $display_id, $phone, $password_hash);
             if ($stmt->execute()) {
@@ -70,12 +65,10 @@ if ($request_method === 'POST') {
             $phone = $data['phone'] ?? null;
             $password = $data['password'] ?? null;
             if (!$phone || !$password) send_json_error(400, '手机号和密码不能为空');
-
             $stmt = $db->prepare("SELECT id, display_id, password_hash, points FROM users WHERE phone_number = ?");
             $stmt->bind_param('s', $phone);
             $stmt->execute();
             $user = $stmt->get_result()->fetch_assoc();
-
             if ($user && password_verify($password, $user['password_hash'])) {
                 $_SESSION['user_id'] = $user['id'];
                 $_SESSION['display_id'] = $user['display_id'];
@@ -96,111 +89,79 @@ if ($request_method === 'POST') {
             $sender_id = $_SESSION['user_id'];
             $recipient_display_id = $data['recipientId'] ?? null;
             $amount = (int)($data['amount'] ?? 0);
-
-            if (!$recipient_display_id || $amount <= 0) {
-                send_json_error(400, '无效的接收人ID或金额');
-            }
-
+            if (!$recipient_display_id || $amount <= 0) send_json_error(400, '无效的接收人ID或金额');
             $db->begin_transaction();
             try {
-                // Get sender's points and lock the row
                 $stmt = $db->prepare("SELECT points FROM users WHERE id = ? FOR UPDATE");
                 $stmt->bind_param('i', $sender_id);
                 $stmt->execute();
                 $sender = $stmt->get_result()->fetch_assoc();
-                if (!$sender || $sender['points'] < $amount) {
-                    throw new Exception('积分不足');
-                }
-
-                // Get recipient's id and lock the row
+                if (!$sender || $sender['points'] < $amount) throw new Exception('积分不足');
                 $stmt = $db->prepare("SELECT id FROM users WHERE display_id = ? FOR UPDATE");
                 $stmt->bind_param('s', $recipient_display_id);
                 $stmt->execute();
                 $recipient = $stmt->get_result()->fetch_assoc();
-                if (!$recipient) {
-                    throw new Exception('接收人ID不存在');
-                }
+                if (!$recipient) throw new Exception('接收人ID不存在');
                 $recipient_id = $recipient['id'];
-
-                if ($sender_id === $recipient_id) {
-                    throw new Exception('不能给自己赠送积分');
-                }
-
-                // Perform transfer
+                if ($sender_id === $recipient_id) throw new Exception('不能给自己赠送积分');
                 $stmt = $db->prepare("UPDATE users SET points = points - ? WHERE id = ?");
                 $stmt->bind_param('ii', $amount, $sender_id);
                 $stmt->execute();
-
                 $stmt = $db->prepare("UPDATE users SET points = points + ? WHERE id = ?");
                 $stmt->bind_param('ii', $amount, $recipient_id);
                 $stmt->execute();
-
                 $db->commit();
-
-                // Update session with new points total
                 $_SESSION['points'] -= $amount;
-
                 echo json_encode(['success' => true, 'message' => "成功赠送 {$amount} 积分"]);
-
             } catch (Exception $e) {
                 $db->rollback();
                 send_json_error(400, $e->getMessage());
             }
             break;
 
-        case 'create_room':
+        case 'matchmake':
             if (!isset($_SESSION['user_id'])) send_json_error(401, '请先登录');
             $user_id = $_SESSION['user_id'];
-
-            $room_code = uniqid('room_');
-            $created_at = date('Y-m-d H:i:s');
-            $stmt = $db->prepare("INSERT INTO rooms (room_code, state, created_at) VALUES (?, 'waiting', ?)");
-            $stmt->bind_param('ss', $room_code, $created_at);
-            if (!$stmt->execute()) send_json_error(500, 'Failed to create room.');
-            $room_id = $db->insert_id;
-
-            $seat = 1;
-            $stmt = $db->prepare("INSERT INTO room_players (room_id, user_id, seat, joined_at) VALUES (?, ?, ?, NOW())");
-            $stmt->bind_param('iii', $room_id, $user_id, $seat);
-            if (!$stmt->execute()) send_json_error(500, 'Failed to add player to room.');
-
-            echo json_encode(['success' => true, 'roomId' => $room_id]);
-            break;
-
-        case 'join_room':
-            if (!isset($_SESSION['user_id'])) send_json_error(401, '请先登录');
-            $user_id = $_SESSION['user_id'];
-            $room_id = (int)($data['roomId'] ?? 0);
-            if (!$room_id) send_json_error(400, 'Missing roomId');
-
-            // Check if user is already in the room
-            $stmt = $db->prepare("SELECT id FROM room_players WHERE room_id=? AND user_id=?");
-            $stmt->bind_param('ii', $room_id, $user_id);
-            $stmt->execute();
-            if ($stmt->get_result()->num_rows > 0) {
-                // User is already in the room, treat it as a success
-                echo json_encode(['success' => true, 'roomId' => $room_id]);
-                break;
+            $game_mode = $data['game_mode'] ?? null;
+            if (!in_array($game_mode, ['normal_2', 'normal_5', 'double_2', 'double_5'])) {
+                send_json_error(400, '无效的游戏模式');
             }
-
-            $stmt = $db->prepare("SELECT COUNT(*) as cnt FROM room_players WHERE room_id=?");
-            $stmt->bind_param('i', $room_id);
-            $stmt->execute();
-            $count = $stmt->get_result()->fetch_assoc()['cnt'];
-            if ($count >= 4) send_json_error(403, '房间已满');
-
-            $seat = $count + 1;
-            $stmt = $db->prepare("INSERT INTO room_players (room_id, user_id, seat, joined_at) VALUES (?, ?, ?, NOW())");
-            $stmt->bind_param('iii', $room_id, $user_id, $seat);
-            if (!$stmt->execute()) send_json_error(500, '加入房间失败');
-
-            echo json_encode(['success' => true, 'roomId' => $room_id]);
+            $db->begin_transaction();
+            try {
+                $stmt = $db->prepare("SELECT r.id, COUNT(rp.id) as player_count FROM rooms r LEFT JOIN room_players rp ON r.id = rp.room_id WHERE r.game_mode = ? AND r.state = 'waiting' GROUP BY r.id HAVING player_count < 4 ORDER BY r.created_at ASC LIMIT 1 FOR UPDATE");
+                $stmt->bind_param('s', $game_mode);
+                $stmt->execute();
+                $room = $stmt->get_result()->fetch_assoc();
+                $room_id = null;
+                if ($room) {
+                    $room_id = $room['id'];
+                    $seat = $room['player_count'] + 1;
+                    $stmt = $db->prepare("INSERT INTO room_players (room_id, user_id, seat, joined_at) VALUES (?, ?, ?, NOW()) ON DUPLICATE KEY UPDATE user_id=user_id");
+                    $stmt->bind_param('iii', $room_id, $user_id, $seat);
+                    $stmt->execute();
+                } else {
+                    $room_code = uniqid('room_');
+                    $created_at = date('Y-m-d H:i:s');
+                    $stmt = $db->prepare("INSERT INTO rooms (game_mode, room_code, state, created_at) VALUES (?, ?, 'waiting', ?)");
+                    $stmt->bind_param('sss', $game_mode, $room_code, $created_at);
+                    $stmt->execute();
+                    $room_id = $db->insert_id;
+                    $seat = 1;
+                    $stmt = $db->prepare("INSERT INTO room_players (room_id, user_id, seat, joined_at) VALUES (?, ?, ?, NOW())");
+                    $stmt->bind_param('iii', $room_id, $user_id, $seat);
+                    $stmt->execute();
+                }
+                $db->commit();
+                echo json_encode(['success' => true, 'roomId' => $room_id]);
+            } catch (Exception $e) {
+                $db->rollback();
+                send_json_error(500, '匹配失败: ' . $e->getMessage());
+            }
             break;
 
         case 'start_game':
             $room_id = (int)($data['roomId'] ?? 0);
             if (!$room_id) send_json_error(400, 'Missing roomId');
-
             $db->begin_transaction();
             try {
                 $stmt = $db->prepare("SELECT user_id FROM room_players WHERE room_id = ?");
@@ -209,9 +170,7 @@ if ($request_method === 'POST') {
                 $players_res = $stmt->get_result();
                 $players = [];
                 while($row = $players_res->fetch_assoc()) $players[] = $row['user_id'];
-
                 if (count($players) < 2) throw new Exception('Not enough players (min 2).');
-
                 $deck = shuffle_deck(create_deck());
                 $hands = array_fill_keys($players, []);
                 for ($i = 0; $i < 13; $i++) {
@@ -219,29 +178,24 @@ if ($request_method === 'POST') {
                         $hands[$player_id][] = array_pop($deck);
                     }
                 }
-
                 $stmt = $db->prepare("UPDATE room_players SET hand_cards = ? WHERE room_id = ? AND user_id = ?");
                 foreach ($players as $player_id) {
                     $hand_json = json_encode($hands[$player_id]);
-                    $stmt->bind_param('sis', $hand_json, $room_id, $player_id);
+                    $stmt->bind_param('sii', $hand_json, $room_id, $player_id);
                     $stmt->execute();
                 }
-
                 $stmt = $db->prepare("INSERT INTO games (room_id, game_state, created_at) VALUES (?, 'setting_hands', NOW())");
                 $stmt->bind_param('i', $room_id);
                 $stmt->execute();
                 $game_id = $db->insert_id;
-
                 $stmt = $db->prepare("UPDATE rooms SET state = 'playing', current_game_id = ? WHERE id = ?");
                 $stmt->bind_param('ii', $game_id, $room_id);
                 $stmt->execute();
-
                 $stmt = $db->prepare("INSERT INTO player_hands (game_id, player_id) VALUES (?, ?)");
                 foreach ($players as $player_id) {
-                    $stmt->bind_param('is', $game_id, $player_id); // 's' for string player_id
+                    $stmt->bind_param('ii', $game_id, $player_id);
                     $stmt->execute();
                 }
-
                 $db->commit();
                 echo json_encode(['success' => true, 'message' => 'Game started', 'gameId' => $game_id]);
             } catch (Exception $e) {
@@ -257,57 +211,40 @@ if ($request_method === 'POST') {
             $front = $data['front'] ?? null;
             $middle = $data['middle'] ?? null;
             $back = $data['back'] ?? null;
-
-            if (!$game_id || !$front || !$middle || !$back) {
-                send_json_error(400, 'Missing required parameters.');
-            }
-
+            if (!$game_id || !$front || !$middle || !$back) send_json_error(400, 'Missing required parameters.');
             $db->begin_transaction();
             try {
                 $analyzer = new ThirteenCardAnalyzer();
                 $front_details = $analyzer->analyze_hand($front);
                 $middle_details = $analyzer->analyze_hand($middle);
                 $back_details = $analyzer->analyze_hand($back);
-
-                $is_valid = $analyzer->compare_hands($back_details, $middle_details) >= 0 &&
-                            $analyzer->compare_hands($middle_details, $front_details) >= 0;
-
+                $is_valid = $analyzer->compare_hands($back_details, $middle_details) >= 0 && $analyzer->compare_hands($middle_details, $front_details) >= 0;
                 $stmt = $db->prepare("UPDATE player_hands SET is_submitted=1, is_valid=?, front_hand=?, middle_hand=?, back_hand=?, front_hand_details=?, middle_hand_details=?, back_hand_details=? WHERE game_id=? AND player_id=?");
-                $stmt->bind_param('issssssii',
-                    $is_valid,
-                    json_encode($front), json_encode($middle), json_encode($back),
-                    json_encode($front_details), json_encode($middle_details), json_encode($back_details),
-                    $game_id, $user_id
-                );
+                $stmt->bind_param('issssssii', $is_valid, json_encode($front), json_encode($middle), json_encode($back), json_encode($front_details), json_encode($middle_details), json_encode($back_details), $game_id, $user_id);
                 $stmt->execute();
-
                 $stmt = $db->prepare("SELECT COUNT(*) as submitted_count FROM player_hands WHERE game_id=? AND is_submitted=1");
                 $stmt->bind_param('i', $game_id);
                 $stmt->execute();
                 $submitted_count = $stmt->get_result()->fetch_assoc()['submitted_count'];
-
                 $stmt = $db->prepare("SELECT COUNT(*) as total_count FROM player_hands WHERE game_id=?");
                 $stmt->bind_param('i', $game_id);
                 $stmt->execute();
                 $total_count = $stmt->get_result()->fetch_assoc()['total_count'];
-
                 if ($submitted_count === $total_count) {
-                    // SHOWDOWN
+                    $stmt = $db->prepare("SELECT game_mode FROM rooms r JOIN games g ON r.id = g.room_id WHERE g.id = ?");
+                    $stmt->bind_param('i', $game_id);
+                    $stmt->execute();
+                    $game_mode = $stmt->get_result()->fetch_assoc()['game_mode'] ?? 'normal_2';
+                    $score_multipliers = ['normal_2' => ['base' => 2, 'double' => 1], 'normal_5' => ['base' => 5, 'double' => 1], 'double_2' => ['base' => 2, 'double' => 2], 'double_5' => ['base' => 5, 'double' => 2]];
+                    $multiplier = $score_multipliers[$game_mode];
                     $stmt = $db->prepare("SELECT * FROM player_hands WHERE game_id=?");
                     $stmt->bind_param('i', $game_id);
                     $stmt->execute();
                     $hands_res = $stmt->get_result();
                     $all_hands = [];
                     while($row = $hands_res->fetch_assoc()) {
-                        $all_hands[$row['player_id']] = [
-                            'isValid' => (bool)$row['is_valid'],
-                            'front' => json_decode($row['front_hand_details'], true),
-                            'middle' => json_decode($row['middle_hand_details'], true),
-                            'back' => json_decode($row['back_hand_details'], true)
-                        ];
+                        $all_hands[$row['player_id']] = ['isValid' => (bool)$row['is_valid'], 'front' => json_decode($row['front_hand_details'], true), 'middle' => json_decode($row['middle_hand_details'], true), 'back' => json_decode($row['back_hand_details'], true)];
                     }
-
-                    // Calculate royalties for each player first
                     $player_royalties = [];
                     foreach($all_hands as $pid => $hand) {
                         if ($hand['isValid']) {
@@ -316,23 +253,19 @@ if ($request_method === 'POST') {
                             $player_royalties[$pid] = ['total' => 0, 'front' => 0, 'middle' => 0, 'back' => 0];
                         }
                     }
-
-                    // Calculate comparison scores
                     $player_comparison_scores = array_fill_keys(array_keys($all_hands), 0);
                     $player_ids = array_keys($all_hands);
-
                     for ($i = 0; $i < count($player_ids); $i++) {
                         for ($j = $i + 1; $j < count($player_ids); $j++) {
                             $p1_id = $player_ids[$i];
                             $p2_id = $player_ids[$j];
                             $p1_hand = $all_hands[$p1_id];
                             $p2_hand = $all_hands[$p2_id];
-
                             $score_diff = 0;
                             if (!$p1_hand['isValid'] && $p2_hand['isValid']) {
-                                $score_diff = -6; // p1 scooped, a common scoring rule
+                                $score_diff = -6;
                             } elseif ($p1_hand['isValid'] && !$p2_hand['isValid']) {
-                                $score_diff = 6; // p2 scooped
+                                $score_diff = 6;
                             } elseif ($p1_hand['isValid'] && $p2_hand['isValid']) {
                                 $score_diff += $analyzer->compare_hands($p1_hand['front'], $p2_hand['front']);
                                 $score_diff += $analyzer->compare_hands($p1_hand['middle'], $p2_hand['middle']);
@@ -342,43 +275,28 @@ if ($request_method === 'POST') {
                             $player_comparison_scores[$p2_id] -= $score_diff;
                         }
                     }
-
-                    // Combine comparison scores and royalties, and update DB
                     $stmt_update_hand = $db->prepare("UPDATE player_hands SET round_score=?, score_details=? WHERE game_id=? AND player_id=?");
                     $stmt_update_total_score = $db->prepare("UPDATE users SET points = points + ? WHERE id = ?");
-
                     foreach($player_comparison_scores as $pid => $comp_score) {
-                        // Each player's royalty score is paid by every other player
                         $total_royalty_payout = 0;
                         foreach ($player_ids as $other_pid) {
                             if ($pid !== $other_pid) {
                                 $total_royalty_payout += ($player_royalties[$pid]['total'] - $player_royalties[$other_pid]['total']);
                             }
                         }
-
-                        $final_round_score = $comp_score + $total_royalty_payout;
-
-                        $score_details = json_encode([
-                            'comparison_score' => $comp_score,
-                            'royalty_details' => $player_royalties[$pid],
-                            'total_royalty_payout' => $total_royalty_payout,
-                            'final_score' => $final_round_score
-                        ]);
-
-                        $stmt_update_hand->bind_param('isis', $final_round_score, $score_details, $game_id, $pid);
+                        $final_round_score = ($comp_score * $multiplier['base'] * $multiplier['double']) + $total_royalty_payout;
+                        $score_details = json_encode(['comparison_score' => $comp_score, 'base_points' => $multiplier['base'], 'double_factor' => $multiplier['double'], 'royalty_details' => $player_royalties[$pid], 'total_royalty_payout' => $total_royalty_payout, 'final_score' => $final_round_score]);
+                        $stmt_update_hand->bind_param('isii', $final_round_score, $score_details, $game_id, $pid);
                         $stmt_update_hand->execute();
-
                         $stmt_update_total_score->bind_param('ii', $final_round_score, $pid);
                         $stmt_update_total_score->execute();
                     }
                     $stmt_update_hand->close();
                     $stmt_update_total_score->close();
-
                     $stmt = $db->prepare("UPDATE games SET game_state='finished' WHERE id=?");
                     $stmt->bind_param('i', $game_id);
                     $stmt->execute();
                 }
-
                 $db->commit();
                 echo json_encode(['success' => true, 'message' => 'Hand submitted.']);
             } catch (Exception $e) {
@@ -403,7 +321,6 @@ if ($request_method === 'POST') {
             if (!isset($_SESSION['user_id'])) send_json_error(401, '请先登录');
             $phone = $_GET['phone'] ?? null;
             if (!$phone) send_json_error(400, '需要提供手机号');
-
             $stmt = $db->prepare("SELECT display_id FROM users WHERE phone_number = ?");
             $stmt->bind_param('s', $phone);
             $stmt->execute();
@@ -414,48 +331,36 @@ if ($request_method === 'POST') {
                 send_json_error(404, '未找到该用户');
             }
             break;
-
         case 'get_room_state':
             $room_id = (int)($_GET['roomId'] ?? 0);
-            $player_id_requesting = $_GET['playerId'] ?? null;
+            $player_id_requesting = $_GET['playerId'] ?? null; // This is now the session user_id
             if (!$room_id) send_json_error(400, 'Missing roomId');
-
             $stmt = $db->prepare("SELECT * FROM rooms WHERE id=?");
             $stmt->bind_param('i', $room_id);
             $stmt->execute();
             $room = $stmt->get_result()->fetch_assoc();
             if (!$room) send_json_error(404, 'Room not found');
-
             $stmt = $db->prepare("SELECT rp.*, u.display_id, u.points FROM room_players rp JOIN users u ON rp.user_id = u.id WHERE rp.room_id=? ORDER BY rp.seat");
             $stmt->bind_param('i', $room_id);
             $stmt->execute();
             $players_res = $stmt->get_result();
             $players = [];
             while ($row = $players_res->fetch_assoc()) {
-                $p_data = [
-                    'id' => $row['user_id'],
-                    'name' => '玩家 ' . $row['display_id'],
-                    'seat' => $row['seat'],
-                    'score' => $row['points'], // Now using persistent points
-                ];
-                if ($row['user_id'] == $player_id_requesting && $row['hand_cards']) {
+                $p_data = ['id' => $row['user_id'], 'name' => '玩家 ' . $row['display_id'], 'seat' => $row['seat'], 'score' => $row['points']];
+                if ($row['user_id'] == ($_SESSION['user_id'] ?? null) && $row['hand_cards']) {
                     $p_data['hand'] = json_decode($row['hand_cards'], true);
                 }
                 $players[] = $p_data;
             }
-
-            $response = ['success' => true, 'room' => ['id' => $room['id'], 'state' => $room['state'], 'players' => $players]];
-
+            $response = ['success' => true, 'room' => ['id' => $room['id'], 'state' => $room['state'], 'players' => $players, 'game_mode' => $room['game_mode']]];
             if ($room['state'] === 'playing' && $room['current_game_id']) {
                 $game_id = $room['current_game_id'];
                 $stmt = $db->prepare("SELECT * FROM games WHERE id=?");
                 $stmt->bind_param('i', $game_id);
                 $stmt->execute();
                 $game = $stmt->get_result()->fetch_assoc();
-
                 if ($game) {
                     $response['game'] = ['id' => $game['id'], 'state' => $game['game_state']];
-
                     $stmt = $db->prepare("SELECT * FROM player_hands WHERE game_id=?");
                     $stmt->bind_param('i', $game_id);
                     $stmt->execute();
@@ -476,10 +381,8 @@ if ($request_method === 'POST') {
                     $response['game']['hands'] = $player_hands;
                 }
             }
-
             echo json_encode($response);
             break;
-
         default:
             send_json_error(404, 'Endpoint not found');
     }

--- a/backend/api/schema.sql
+++ b/backend/api/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE `users` (
 -- The `rooms` table holds information about a game lobby.
 CREATE TABLE `rooms` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
+  `game_mode` enum('normal_2','normal_5','double_2','double_5') NOT NULL,
   `room_code` varchar(255) NOT NULL UNIQUE,
   `state` enum('waiting','playing','finished') NOT NULL DEFAULT 'waiting',
   `current_game_id` int(11) DEFAULT NULL,

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -30,9 +30,36 @@
   cursor: pointer;
 }
 
-.room-management {
-  margin-top: 50px;
+.room-management, .game-mode-selection {
+  margin: 50px auto;
+  padding: 20px;
+  max-width: 600px;
+  background-color: rgba(0,0,0,0.2);
+  border: 1px solid #c9a477;
+  border-radius: 8px;
 }
+
+.mode-buttons {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 15px;
+}
+
+.mode-buttons button {
+  padding: 20px;
+  font-size: 1.2em;
+  background-color: #c9a477;
+  color: black;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.mode-buttons button:hover {
+  background-color: #e6bf8e;
+}
+
 
 /* --- New Game Layout System --- */
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -40,9 +40,7 @@ export const transferPoints = (recipientId, amount) => request('transfer_points'
 
 
 // --- Game Endpoints ---
-export const createRoom = () => request('create_room', 'POST');
-export const joinRoom = (roomId) => request('join_room', 'POST', { roomId });
-// getRoomState still needs the current player's ID to know which hand to return
+export const matchmake = (game_mode) => request('matchmake', 'POST', { game_mode });
 export const getRoomState = (roomId, playerId) => request(`get_room_state&roomId=${roomId}&playerId=${playerId}`);
 export const startGame = (roomId) => request('start_game', 'POST', { roomId });
 


### PR DESCRIPTION
This commit replaces the manual 'Create/Join Room' system with an automatic matchmaking flow based on different game modes.

- **Backend:**
  - The `rooms` table in `schema.sql` now has a `game_mode` column.
  - The scoring logic in `api.php` has been updated to use multipliers based on the selected game mode (e.g., 2-point, 5-point, double).
  - A new `/matchmake` endpoint has been created. It finds a suitable waiting room or creates a new one for the player based on their chosen game mode.
  - The old `/create_room` and `/join_room` endpoints have been removed.

- **Frontend:**
  - The `App.js` component has been updated to remove the old room management UI.
  - A new UI section with buttons for the four different game modes has been added.
  - The frontend now calls the `/matchmake` API to enter a game.
  - The `api.js` file has been updated to reflect these changes.