### PR TITLE
fix(cicd): Add debugging steps to Android release workflow

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -72,14 +72,17 @@ jobs:
         run: chmod +x ./gradlew
         working-directory: ./frontend/android
 
-      - name: Build Release APK
-        run: ./gradlew assembleRelease
+      - name: Build Release APK with Stacktrace
+        run: ./gradlew assembleRelease --stacktrace
         working-directory: ./frontend/android
         env:
           KEYSTORE_PATH: ${{ steps.decode_keystore.outputs.keystore_path }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+
+      - name: List Build Output
+        run: ls -R frontend/android/app/build/outputs/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This commit adds debugging steps to the `android_build.yml` workflow to help diagnose the cause of the APK build failure.

- The Gradle build command (`./gradlew assembleRelease`) is now run with the `--stacktrace` flag to provide more detailed error output.
- A new step, 'List Build Output', has been added after the build command. It runs `ls -R frontend/android/app/build/outputs/` to recursively list all generated files. This will help confirm if an APK is being created and what its exact name and path are.

These changes are intended to provide the necessary logs to identify and fix the root cause of the release failure.