### PR TITLE
fix(cicd): Final correction for Android release workflow

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -24,26 +24,23 @@ jobs:
         uses: actions/setup-java@v4
         with: { java-version: '21', distribution: 'temurin' }
       - uses: actions/setup-node@v4
-        with: { node-version: '20', cache: 'npm', cache-dependency-path: '**/package-lock.json' }
+        with: { node-version: '20', cache: 'npm', cache-dependency-path: 'frontend/package-lock.json' }
       - name: 3. Set up Android SDK
         uses: android-actions/setup-android@v3
 
       # --- 2. PREPARE ---
-      - name: 4. Install All Dependencies
-        run: |
-          npm install
-          cd frontend
-          npm install
-          cd ..
+      - name: 4. Install Frontend Dependencies
+        run: npm install
+        working-directory: ./frontend
       - name: 5. Build Frontend Web App
-        run: |
-          cd frontend
-          npm run build
-          cd ..
+        run: npm run build
+        working-directory: ./frontend
       - name: 6. Capacitor Sync
         run: npx cap sync android
+        working-directory: ./frontend
       - name: 7. Grant execute permission for gradlew
-        run: chmod +x android/gradlew
+        run: chmod +x ./gradlew
+        working-directory: ./frontend/android
       - name: 8. Generate Versioning Info
         id: versioning
         run: |
@@ -52,15 +49,14 @@ jobs:
 
       # --- 3. BUILD DEBUG APK ---
       - name: 9. Build Debug APK
-        working-directory: ./android
+        working-directory: ./frontend/android
         run: ./gradlew assembleDebug
 
       - name: 10. Upload Debug APK as Artifact
-        # 将 Debug 包作为 Artifact 上传，它不会出现在 Release 页面
         uses: actions/upload-artifact@v4
         with:
           name: 摆牌-Debug-Build-${{ steps.versioning.outputs.version_name }}
-          path: android/app/build/outputs/apk/debug/app-debug.apk
+          path: frontend/android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: 7
 
       # --- 4. BUILD RELEASE APK ---
@@ -68,7 +64,7 @@ jobs:
         run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > my-release-key.keystore
 
       - name: 12. Build Signed Release APK
-        working-directory: ./android
+        working-directory: ./frontend/android
         run: |
           ./gradlew assembleRelease \
             -PappVersionCode=${{ steps.versioning.outputs.version_code }} \
@@ -79,15 +75,15 @@ jobs:
             -Pandroid.injected.signing.key.password="${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
 
       - name: 13. Rename Release APK
-        run: mv android/app/build/outputs/apk/release/app-release.apk android/app/build/outputs/apk/release/摆牌-Release-${{ steps.versioning.outputs.version_name }}.apk
+        working-directory: ./frontend/android/app/build/outputs/apk/release
+        run: mv app-release.apk 摆牌-Release-${{ steps.versioning.outputs.version_name }}.apk
 
       - name: 14. Create GitHub Release with a single APK
-        # [重要] 这里我们只把签名的 Release 包发布到 Release 页面
         uses: ncipollo/release-action@v1
         with:
           tag: release-${{ github.sha }}
           name: "自动构建 - ${{ github.event.head_commit.message }}"
-          artifacts: "android/app/build/outputs/apk/release/*.apk"
+          artifacts: "frontend/android/app/build/outputs/apk/release/*.apk"
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
           prerelease: true


### PR DESCRIPTION
This commit provides the final, corrected version of the `.github/workflows/android_build.yml` file.

Based on the user's provided, working example and subsequent debugging, this version:
- Correctly installs dependencies only in the `frontend` directory.
- Uses the `working-directory` parameter consistently and correctly for all steps, including `npm run build`, `npx cap sync`, and `gradlew`.
- Implements a robust, single-job pipeline that builds both debug and release APKs and creates a GitHub Release on every push to the `main` branch.

This should resolve all previously reported CI/CD failures.