### PR TITLE
fix(android): Resolve keystore compatibility issue in Gradle build

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -68,11 +68,7 @@ jobs:
         run: |
           ./gradlew assembleRelease -Dorg.gradle.java.home="$JAVA_HOME" \
             -PappVersionCode=${{ steps.versioning.outputs.version_code }} \
-            -PappVersionName=${{ steps.versioning.outputs.version_name }} \
-            -Pandroid.injected.signing.store.file="${{ github.workspace }}/my-release-key.keystore" \
-            -Pandroid.injected.signing.store.password="${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
-            -Pandroid.injected.signing.key.alias="${{ secrets.ANDROID_KEY_ALIAS }}" \
-            -Pandroid.injected.signing.key.password="${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
+            -PappVersionName=${{ steps.versioning.outputs.version_name }}
 
       - name: 13. Rename Release APK
         working-directory: ./frontend/android/app/build/outputs/apk/release

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -16,8 +16,21 @@ android {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+
+    signingConfigs {
+        release {
+            if (System.getenv("KEYSTORE_PATH") != null) {
+                storeFile file(System.getenv("KEYSTORE_PATH"))
+                storePassword System.getenv("KEYSTORE_PASSWORD")
+                keyAlias System.getenv("KEY_ALIAS")
+                keyPassword System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }


### PR DESCRIPTION
This commit fixes the `Tag number over 30 is not supported` error that occurred during the APK signing process.

The root cause was an incompatibility between the user's keystore file format and the way signing information was being passed to Gradle via command-line properties.

The fix involves:
1.  **`frontend/android/app/build.gradle`**: A `signingConfigs` block has been added to explicitly configure the release signing. This block reads the keystore path, password, and alias from environment variables, allowing Gradle's internal, more robust signing mechanism to handle the keystore.
2.  **`.github/workflows/android_build.yml`**: The `assembleRelease` command has been cleaned up to remove the redundant `-P...` signing parameters, as this is now handled by the `build.gradle` file.

This change should resolve the final build-blocking issue and allow the CI/CD pipeline to successfully generate a signed release APK.