### PR TITLE
fix(android): Revert to command-line signing parameters in CI/CD

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -65,15 +65,14 @@ jobs:
 
       - name: 12. Build Signed Release APK
         working-directory: ./frontend/android
-        env:
-          KEYSTORE_PATH: ${{ github.workspace }}/my-release-key.keystore
-          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
         run: |
           ./gradlew assembleRelease -Dorg.gradle.java.home="$JAVA_HOME" \
             -PappVersionCode=${{ steps.versioning.outputs.version_code }} \
-            -PappVersionName=${{ steps.versioning.outputs.version_name }}
+            -PappVersionName=${{ steps.versioning.outputs.version_name }} \
+            -Pandroid.injected.signing.store.file="${{ github.workspace }}/my-release-key.keystore" \
+            -Pandroid.injected.signing.store.password="${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
+            -Pandroid.injected.signing.key.alias="${{ secrets.ANDROID_KEY_ALIAS }}" \
+            -Pandroid.injected.signing.key.password="${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
 
       - name: 13. Rename Release APK
         working-directory: ./frontend/android/app/build/outputs/apk/release

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -17,20 +17,8 @@ android {
         }
     }
 
-    signingConfigs {
-        release {
-            if (System.getenv("KEYSTORE_PATH") != null) {
-                storeFile file(System.getenv("KEYSTORE_PATH"))
-                storePassword System.getenv("KEYSTORE_PASSWORD")
-                keyAlias System.getenv("KEY_ALIAS")
-                keyPassword System.getenv("KEY_PASSWORD")
-            }
-        }
-    }
-
     buildTypes {
         release {
-            signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }


### PR DESCRIPTION
This commit represents a final attempt to resolve the `KeytoolException: Tag number over 30 is not supported` error during the Android build.

Based on user feedback insisting the issue is not with the keystore file itself, this change reverts the signing mechanism to a previous state while keeping other build fixes in place.

1.  **`frontend/android/app/build.gradle`**: The `signingConfigs` block that was previously added has been removed. The Gradle script will no longer handle the signing configuration internally.
2.  **`.github/workflows/android_build.yml`**: The `Build Signed Release APK` step has been modified to pass all signing information as command-line properties (`-P...`) directly to the `gradlew` command. The `env` block for this step has been removed.

This change isolates the problem. If the build continues to fail with the same error, it will definitively confirm that the issue lies with the keystore file format itself and cannot be resolved by code or configuration changes in the repository.