### PR TITLE
Fix: Correct cache-dependency-path in android_build.yml

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v4
         with: { java-version: '21', distribution: 'temurin' }
       - uses: actions/setup-node@v4
-        with: { node-version: '20', cache: 'npm', cache-dependency-path: 'frontend/package-lock.json' }
+        with: { node-version: '20', cache: 'npm', cache-dependency-path: 'frontend' }
       - name: 3. Set up Android SDK
         uses: android-actions/setup-android@v3
 


### PR DESCRIPTION
The `actions/setup-node` action was failing with the error "Some specified paths were not resolved, unable to cache dependencies." This is a known issue when `cache-dependency-path` points to a `package-lock.json` file in a subdirectory.

This commit fixes the issue by changing the `cache-dependency-path` from `frontend/package-lock.json` to `frontend`, which is the directory containing the lock file. This allows the action to correctly find the file and cache the npm dependencies.