### PR TITLE
fix: Correct Cloudflare Pages build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "root-build-helper",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "cd frontend && npm install && npm run build"
+  },
+  "workspaces": [
+    "frontend",
+    "backend"
+  ]
+}


### PR DESCRIPTION
Creates a `package.json` file in the repository root to explicitly control the build process on Cloudflare Pages.

The build script now correctly navigates into the `/frontend` directory, installs dependencies, and runs the Vite build from the correct location.

This is intended to fix the 'blank page' issue caused by an improper build environment where no JavaScript assets were being generated.