### PR TITLE
feat: Implement betting panel for lottery simulation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node_modules/.bin/vite build",
+    "build": "node_modules/.bin/tsc -b && node_modules/.bin/vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/frontend/src/components/BettingPanel.tsx
+++ b/frontend/src/components/BettingPanel.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+const BettingPanel: React.FC = () => {
+  const [selectedNumbers, setSelectedNumbers] = useState<number[]>([]);
+  const numbers = Array.from({ length: 49 }, (_, i) => i + 1);
+
+  const handleNumberClick = (num: number) => {
+    if (selectedNumbers.includes(num)) {
+      setSelectedNumbers(selectedNumbers.filter(n => n !== num));
+    } else {
+      if (selectedNumbers.length < 6) {
+        setSelectedNumbers([...selectedNumbers, num].sort((a, b) => a - b));
+      }
+    }
+  };
+
+  const handleClear = () => {
+    setSelectedNumbers([]);
+  };
+
+  return (
+    <div style={{ marginTop: '20px', border: '1px solid #ccc', padding: '10px' }}>
+      <h3>选择号码</h3>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '5px', maxWidth: '400px' }}>
+        {numbers.map(num => (
+          <button
+            key={num}
+            onClick={() => handleNumberClick(num)}
+            style={{
+              padding: '10px',
+              backgroundColor: selectedNumbers.includes(num) ? 'lightblue' : 'white',
+              border: '1px solid #ccc',
+              cursor: 'pointer'
+            }}
+            disabled={selectedNumbers.length >= 6 && !selectedNumbers.includes(num)}
+          >
+            {num}
+          </button>
+        ))}
+      </div>
+      <div style={{ marginTop: '10px' }}>
+        <strong>已选号码: </strong>
+        <span>{selectedNumbers.join(', ')}</span>
+      </div>
+      <div style={{ marginTop: '10px' }}>
+        <button onClick={handleClear}>清除</button>
+        <button style={{ marginLeft: '10px' }} disabled>提交投注</button>
+      </div>
+    </div>
+  );
+};
+
+export default BettingPanel;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 // frontend/src/pages/Home.tsx
 import React, { useState, useEffect } from 'react';
 import { getLatestDraw } from '../api';
+import BettingPanel from '../components/BettingPanel';
 
 interface DrawData {
   period: string;
@@ -47,6 +48,7 @@ const Home: React.FC = () => {
         </div>
       )}
       {/* 在这里添加投注面板等其他组件 */}
+      <BettingPanel />
     </div>
   );
 };


### PR DESCRIPTION
This commit introduces a new "Betting Panel" feature to the frontend application. This is in response to the user's request to "improve the frontend".

The new feature includes:
- A new `BettingPanel` component that allows users to select 6 numbers from a grid of 49.
- Integration of the new component into the main `Home` page.
- Re-enabling of TypeScript type checking in the build process to improve code quality.