### PR TITLE
feat: Display Telegram channel information

### DIFF
--- a/backend/api/config.php
+++ b/backend/api/config.php
@@ -13,7 +13,7 @@ define('DB_PATH', __DIR__ . '/thirteen_game.db');
 // --- Telegram Bot Configuration (Optional) ---
 // These are not used in the current application logic but are kept for potential future use.
 define('TELEGRAM_BOT_TOKEN', 'YOUR_BOT_TOKEN');
-define('TELEGRAM_BOT_ID', 'YOUR_BOT_ID');
+define('TELEGRAM_CHANNEL_ID', 'YOUR_CHANNEL_ID');
 
 // --- Game Logic Configuration ---
 // Payout multiplier for winning bets.

--- a/backend/api/get_channel_info.php
+++ b/backend/api/get_channel_info.php
@@ -1,0 +1,47 @@
+<?php
+// backend/api/get_channel_info.php
+require_once 'config.php';
+header('Content-Type: application/json');
+
+// Check if the Telegram constants are defined and not the placeholder values
+if (!defined('TELEGRAM_BOT_TOKEN') || !defined('TELEGRAM_CHANNEL_ID') || TELEGRAM_BOT_TOKEN === 'YOUR_BOT_TOKEN' || TELEGRAM_CHANNEL_ID === 'YOUR_CHANNEL_ID') {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Telegram Bot Token or Channel ID is not configured on the server.']);
+    exit;
+}
+
+$token = TELEGRAM_BOT_TOKEN;
+$channel_id = TELEGRAM_CHANNEL_ID;
+
+$api_url = "https://api.telegram.org/bot{$token}/getChat?chat_id={$channel_id}";
+
+// Use file_get_contents to make the API request.
+// The '@' suppresses warnings on failure, which we handle manually.
+$response = @file_get_contents($api_url);
+
+if ($response === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Failed to connect to the Telegram API.']);
+    exit;
+}
+
+$data = json_decode($response, true);
+
+if (!$data || !$data['ok']) {
+    http_response_code(500);
+    $error_message = $data['description'] ?? 'An unknown error occurred with the Telegram API.';
+    echo json_encode(['success' => false, 'message' => "Telegram API Error: " . $error_message]);
+    exit;
+}
+
+// Extract the relevant information from the 'result' object
+$channel_info = $data['result'];
+
+echo json_encode(['success' => true, 'data' => [
+    'title' => $channel_info['title'] ?? null,
+    'description' => $channel_info['description'] ?? null,
+    'invite_link' => $channel_info['invite_link'] ?? null,
+    // Note: members_count is only returned for supergroups and channels.
+    'members_count' => $channel_info['members_count'] ?? null,
+]]);
+?>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -15,3 +15,7 @@ export const getLatestDraw = () => {
 export const placeBet = (numbers: number[]) => {
   return apiClient.post('/api/place_bet.php', { numbers });
 };
+
+export const getChannelInfo = () => {
+  return apiClient.get('/api/get_channel_info.php');
+};

--- a/frontend/src/components/ChannelInfo.tsx
+++ b/frontend/src/components/ChannelInfo.tsx
@@ -1,0 +1,55 @@
+import React, { useState, useEffect } from 'react';
+import { getChannelInfo } from '../api';
+
+interface ChannelData {
+  title: string;
+  description: string;
+  invite_link: string;
+  members_count: number;
+}
+
+const ChannelInfo: React.FC = () => {
+  const [channelInfo, setChannelInfo] = useState<ChannelData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchInfo = async () => {
+      try {
+        setLoading(true);
+        const response = await getChannelInfo();
+        if (response.data.success) {
+          setChannelInfo(response.data.data);
+        } else {
+          setError(response.data.message);
+        }
+      } catch (err: any) {
+        setError(err.response?.data?.message || 'Failed to fetch channel info.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchInfo();
+  }, []);
+
+  if (loading) return <p>Loading channel info...</p>;
+  if (error) return <p style={{ color: 'red' }}>Error: {error}</p>;
+
+  return (
+    <div style={{ marginTop: '20px', border: '1px solid #ccc', padding: '10px' }}>
+      <h3>Channel Information</h3>
+      {channelInfo && channelInfo.title ? (
+        <>
+          <h4>{channelInfo.title}</h4>
+          <p>{channelInfo.description}</p>
+          {channelInfo.invite_link && <a href={channelInfo.invite_link} target="_blank" rel="noopener noreferrer">Join Channel</a>}
+          {channelInfo.members_count && <p>Members: {channelInfo.members_count}</p>}
+        </>
+      ) : (
+        <p>No channel information available.</p>
+      )}
+    </div>
+  );
+};
+
+export default ChannelInfo;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { getLatestDraw } from '../api';
 import BettingPanel from '../components/BettingPanel';
+import ChannelInfo from '../components/ChannelInfo';
 
 interface DrawData {
   period: string;
@@ -49,6 +50,7 @@ const Home: React.FC = () => {
       )}
       {/* 在这里添加投注面板等其他组件 */}
       <BettingPanel />
+      <ChannelInfo />
     </div>
   );
 };


### PR DESCRIPTION
This commit introduces a new feature that fetches information about a Telegram channel and displays it on the frontend.

This is the first part of the Telegram bot integration.

Key changes include:
- **Backend:**
  - Added a new API endpoint `get_channel_info.php`.
  - This endpoint uses the Telegram Bot API (`getChat` method) to retrieve channel details like title, description, and invite link.
  - Updated `config.php` to use a clearer `TELEGRAM_CHANNEL_ID` constant.

- **Frontend:**
  - Created a new `ChannelInfo` component to display the fetched data.
  - Added a new `getChannelInfo` function to the API client.
  - Integrated the `ChannelInfo` component into the home page.