### PR TITLE
fix(ci): Prevent frontend deployment from deleting backend files

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Deploy to serv00
         run: |
-          rsync -avz --delete -e "ssh -o StrictHostKeyChecking=no" ./frontend/dist/ "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}:${{ secrets.SERV00_PATH }}/"
+          rsync -avz --delete --exclude '/api' -e "ssh -o StrictHostKeyChecking=no" ./frontend/dist/ "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}:${{ secrets.SERV00_PATH }}/"


### PR DESCRIPTION
The `deploy-frontend.yml` workflow was using `rsync --delete` without any exclusion rules. This caused the frontend deployment to wipe the `api/` directory from the server, where the backend files are located.

This commit fixes the issue by adding an `--exclude '/api'` flag to the `rsync` command. This ensures that the `api/` directory is not touched during frontend deployments, while still allowing `rsync` to clean up old frontend build artifacts.