### PR TITLE
refactor(backend): Switch from SQLite to MySQL database

### DIFF
--- a/backend/api/config.php
+++ b/backend/api/config.php
@@ -6,9 +6,11 @@
  */
 
 // --- Database Configuration ---
-// Defines the path to the SQLite database file.
-// This file will be automatically created in the same directory as this script.
-define('DB_PATH', __DIR__ . '/thirteen_game.db');
+// Defines the connection details for the MySQL database.
+define('DB_HOST', 'your_database_host');
+define('DB_NAME', 'your_database_name');
+define('DB_USER', 'your_database_user');
+define('DB_PASS', 'your_database_password');
 
 // --- Telegram Bot Configuration (Optional) ---
 // These are not used in the current application logic but are kept for potential future use.

--- a/backend/api/db_init.php
+++ b/backend/api/db_init.php
@@ -3,16 +3,23 @@
 require_once 'config.php';
 
 try {
-    $pdo = new PDO('sqlite:' . DB_PATH);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    // Establish connection to MySQL
+    $dsn = "mysql:host=" . DB_HOST . ";dbname=" . DB_NAME . ";charset=utf8mb4";
+    $options = [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false,
+    ];
+    $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
 
-    // Create draws table
-    $pdo->exec("CREATE TABLE IF NOT EXISTS draws (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        period TEXT NOT NULL UNIQUE,
-        winning_numbers TEXT NOT NULL,
+    // SQL to create draws table for MySQL
+    $sql_draws = "CREATE TABLE IF NOT EXISTS draws (
+        id INT PRIMARY KEY AUTO_INCREMENT,
+        period VARCHAR(255) NOT NULL UNIQUE,
+        winning_numbers VARCHAR(255) NOT NULL,
         draw_time DATETIME NOT NULL
-    )");
+    ) ENGINE=InnoDB;";
+    $pdo->exec($sql_draws);
 
     // Check if there is any data in draws table
     $stmt = $pdo->query("SELECT COUNT(*) FROM draws");
@@ -25,19 +32,24 @@ try {
         ");
     }
 
-    // Create bets table
-    $pdo->exec("CREATE TABLE IF NOT EXISTS bets (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        user_id TEXT NOT NULL,
-        numbers TEXT NOT NULL,
-        period TEXT NOT NULL,
-        bet_time DATETIME DEFAULT CURRENT_TIMESTAMP,
+    // SQL to create bets table for MySQL
+    $sql_bets = "CREATE TABLE IF NOT EXISTS bets (
+        id INT PRIMARY KEY AUTO_INCREMENT,
+        user_id VARCHAR(255) NOT NULL,
+        numbers VARCHAR(255) NOT NULL,
+        period VARCHAR(255) NOT NULL,
+        bet_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (period) REFERENCES draws (period)
-    )");
+    ) ENGINE=InnoDB;";
+    $pdo->exec($sql_bets);
 
-    echo "Database initialized successfully. Tables 'draws' and 'bets' are ready.";
+    echo "Database initialized successfully. Tables 'draws' and 'bets' are ready for MySQL.";
 
 } catch (PDOException $e) {
-    die("Database initialization failed: " . $e->getMessage());
+    // It's better not to expose detailed error messages in production
+    // For debugging, you can uncomment the line below
+    // die("Database initialization failed: " . $e->getMessage());
+    http_response_code(500);
+    die("Database initialization failed. Please check the server logs.");
 }
 ?>

--- a/backend/api/get_latest_draw.php
+++ b/backend/api/get_latest_draw.php
@@ -4,14 +4,13 @@ require_once 'config.php';
 header('Content-Type: application/json');
 
 try {
-    if (!file_exists(DB_PATH)) {
-        http_response_code(500);
-        echo json_encode(['success' => false, 'message' => 'Database does not exist. Please run db_init.php']);
-        exit;
-    }
-
-    $pdo = new PDO('sqlite:' . DB_PATH);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $dsn = "mysql:host=" . DB_HOST . ";dbname=" . DB_NAME . ";charset=utf8mb4";
+    $options = [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false,
+    ];
+    $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
 
     $stmt = $pdo->query("SELECT period, winning_numbers, draw_time FROM draws ORDER BY draw_time DESC LIMIT 1");
     $latest_draw = $stmt->fetch(PDO::FETCH_ASSOC);

--- a/backend/api/place_bet.php
+++ b/backend/api/place_bet.php
@@ -35,8 +35,13 @@ foreach ($numbers as $num) {
 }
 
 try {
-    $pdo = new PDO('sqlite:' . DB_PATH);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $dsn = "mysql:host=" . DB_HOST . ";dbname=" . DB_NAME . ";charset=utf8mb4";
+    $options = [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false,
+    ];
+    $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
 
     // Get the latest draw period
     $stmt = $pdo->query("SELECT period FROM draws ORDER BY draw_time DESC LIMIT 1");


### PR DESCRIPTION
This commit refactors the backend to use a standard MySQL database instead of the file-based SQLite database, as requested by the user.

This change allows the application to connect to a standard, external database server, which is more scalable and aligns with the user's requirement to not generate local files on the server.

Key changes include:
- Updated `config.php` to use MySQL connection parameters (host, name, user, password).
- Modified the `db_init.php` script to create tables with MySQL-compatible SQL.
- Updated the PDO connection logic in all API endpoints (`get_latest_draw.php`, `place_bet.php`) to connect to the MySQL database.