### PR TITLE
fix(api): Handle CORS preflight for registration endpoint

### DIFF
--- a/backend/api/register.php
+++ b/backend/api/register.php
@@ -2,7 +2,22 @@
 // backend/api/register.php
 require_once 'config.php';
 require_once 'db_connect.php';
+
 header('Content-Type: application/json');
+// Handle CORS preflight request
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    header('Access-Control-Allow-Origin: *'); // Or specify your frontend origin
+    header('Access-Control-Allow-Methods: POST, OPTIONS');
+    header('Access-Control-Allow-Headers: Content-Type');
+    exit;
+}
+
+// Ensure the request method is POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Only POST method is allowed.']);
+    exit;
+}
 
 // --- Input Validation ---
 $data = json_decode(file_get_contents('php://input'), true);


### PR DESCRIPTION
This commit fixes a "405 Method Not Allowed" error that occurred when the frontend tried to register a new user.

The error was caused by the `register.php` script not handling the browser's preflight `OPTIONS` request, which is sent before the actual `POST` request for cross-origin API calls.

This fix adds the necessary headers and logic to the top of `register.php` to correctly handle the `OPTIONS` request and explicitly allow the `POST` method.