### PR TITLE
feat: Implement user management features for Telegram bot

### DIFF
--- a/backend/api/db_init.php
+++ b/backend/api/db_init.php
@@ -60,6 +60,7 @@ try {
         password_hash VARCHAR(255) NOT NULL,
         phone VARCHAR(255) NULL UNIQUE,
         points INT NOT NULL DEFAULT 0,
+        is_banned TINYINT(1) NOT NULL DEFAULT 0,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     ) ENGINE=InnoDB;";
     $pdo->exec($sql_users);


### PR DESCRIPTION
This commit adds several new user management features to the Telegram bot, allowing administrators to:
- Edit a user's points with the `/setpoints` command.
- Ban a user with the `/ban` command.
- Unban a user with the `/unban` command.
- Reset a user's password with the `/resetpassword` command.
- List all users with the `/listusers` command.

The `users` table in the database has been updated with an `is_banned` column to support the ban/unban functionality.

The admin keyboard has also been updated with new buttons to guide the administrator on how to use these new commands.