### PR TITLE
fix: Add .user.ini to force PHP error logging

### DIFF
--- a/backend/api/.user.ini
+++ b/backend/api/.user.ini
@@ -1,0 +1,6 @@
+; PHP settings for serv00.com hosting
+; This file enables error logging to a specific file.
+
+log_errors = On
+display_errors = Off
+error_log = /usr/home/wenge95222/domains/wenge.cloudns.ch/phperror.log


### PR DESCRIPTION
This commit adds a `.user.ini` file to the `backend/api/` directory.

This configuration file forces PHP to enable `log_errors` and directs the output to a predictable file path on the user's serv00.com server. This is a necessary step to debug the issue with the Telegram bot not responding, as it will allow us to inspect the script's execution and any potential errors.