### PR TITLE
fix: Resolve cross-domain session login issue

### DIFF
--- a/backend/api/check_session.php
+++ b/backend/api/check_session.php
@@ -1,6 +1,7 @@
 <?php
 // backend/api/check_session.php
 
+require_once __DIR__ . '/session_config.php';
 session_start();
 
 header('Content-Type: application/json');

--- a/backend/api/login.php
+++ b/backend/api/login.php
@@ -14,7 +14,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit();
 }
 
-// Start the session
+// Configure and start the session
+require_once __DIR__ . '/session_config.php';
 session_start();
 
 $response = ['success' => false, 'message' => 'An unknown error occurred.'];

--- a/backend/api/logout.php
+++ b/backend/api/logout.php
@@ -1,6 +1,7 @@
 <?php
 // backend/api/logout.php
 
+require_once __DIR__ . '/session_config.php';
 session_start();
 session_unset();
 session_destroy();

--- a/backend/api/session_config.php
+++ b/backend/api/session_config.php
@@ -1,0 +1,20 @@
+<?php
+// backend/api/session_config.php
+
+// This configuration ensures that session cookies work correctly
+// when the frontend and backend are on different domains.
+
+// The frontend is on a subdomain of .wenxiuxiu.eu.org
+// The backend is on a different domain, but proxied through the same Cloudflare Worker.
+// We need to set the cookie domain to allow subdomains and be sent cross-site.
+
+// Set cookie parameters BEFORE starting the session.
+session_set_cookie_params([
+    'lifetime' => 86400 * 7, // 7 days
+    'path' => '/',
+    'domain' => '.wenxiuxiu.eu.org', // The leading dot allows the cookie to be shared across all subdomains.
+    'secure' => true,   // The cookie will only be sent over HTTPS connections.
+    'httponly' => true, // The cookie cannot be accessed by client-side scripts, which helps prevent XSS attacks.
+    'samesite' => 'None' // Required for the cookie to be sent in cross-site requests (e.g., from your frontend domain to the proxied backend).
+]);
+?>


### PR DESCRIPTION
This commit fixes the user login functionality, which was failing due to cross-domain cookie restrictions.

- A new `session_config.php` file has been created to centrally manage session cookie parameters.
- The configuration sets the cookie's `domain`, `secure`, and `samesite` attributes, allowing the session to persist when the frontend and backend are on different domains.
- The `login.php`, `logout.php`, and `check_session.php` scripts have been updated to use this new configuration before starting a session.