### PR TITLE
feat: Add default game rules to database migration

### DIFF
--- a/backend/migrations/2025_09_17_000000_create_lottery_tables.php
+++ b/backend/migrations/2025_09_17_000000_create_lottery_tables.php
@@ -57,15 +57,24 @@ CREATE TABLE `lottery_rules` (
 ";
 $pdo->exec($sql_create_rules);
 
-// 4. Pre-populate the rules table with default structures.
+// 4. Pre-populate the rules table with default game data.
+$zodiac_json = '{"蛇":[1,13,25,37,49],"龙":[2,14,26,38],"兔":[3,15,27,39],"虎":[4,16,28,40],"牛":[5,17,29,41],"鼠":[6,18,30,42],"猪":[7,19,31,43],"狗":[8,20,32,44],"鸡":[9,21,33,45],"猴":[10,22,34,46],"羊":[11,23,35,47],"马":[12,24,36,48]}';
+$color_json = '{"红波":[1,7,13,19,23,29,35,45,2,8,12,18,24,30,34,40,46],"蓝波":[3,9,15,25,31,37,41,47,4,10,14,20,26,36,42,48],"绿波":[5,11,17,21,27,33,39,43,49,6,16,22,28,32,38,44]}';
+$odds_json = '{"special":47,"default":45}';
+
 $sql_populate_rules = "
 INSERT INTO `lottery_rules` (rule_key, rule_value) VALUES
-('zodiac_mappings', '{}'),
-('color_mappings', '{}'),
-('odds', '{\"special\": 47, \"default\": 45}')
-ON DUPLICATE KEY UPDATE rule_key=rule_key; -- Do nothing if keys already exist
+('zodiac_mappings', :zodiac_json),
+('color_mappings', :color_json),
+('odds', :odds_json)
+ON DUPLICATE KEY UPDATE rule_value = VALUES(rule_value);
 ";
-$pdo->exec($sql_populate_rules);
+$stmt = $pdo->prepare($sql_populate_rules);
+$stmt->execute([
+    ':zodiac_json' => $zodiac_json,
+    ':color_json' => $color_json,
+    ':odds_json' => $odds_json,
+]);
 
 // No statement needs to be returned as execution is handled internally.
 ?>


### PR DESCRIPTION
This commit updates the database migration script to pre-populate the lottery_rules table with the specific Zodiac-to-number and Color-to-number mappings provided by the user. This ensures the system has the correct game data upon initial setup.