### PR TITLE
Refactor backend configuration to use .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ logs
 # IDE files
 .idea/
 .vscode/
+
+# Project-specific ignores
+/backend/vendor/
+/backend/api/.env

--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -1,0 +1,10 @@
+# Database Configuration
+DB_HOST=your_database_host
+DB_NAME=your_database_name
+DB_USER=your_database_user
+DB_PASS=your_database_password
+
+# Telegram Bot Configuration
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+TELEGRAM_CHANNEL_ID=your_telegram_channel_id
+TELEGRAM_SUPER_ADMIN_ID=your_telegram_super_admin_id

--- a/backend/api/config.php
+++ b/backend/api/config.php
@@ -3,18 +3,44 @@
 
 /**
  * Application Configuration
+ *
+ * This file loads environment variables from a .env file and defines them as constants.
  */
 
-// --- Database Configuration ---
-define('DB_HOST', 'mysql12.serv00.com');
-define('DB_NAME', 'm10300_sj');
-define('DB_USER', 'm10300_yh');
-define('DB_PASS', 'Wenxiu1234*');
+// 1. Require the Composer autoloader
+require_once __DIR__ . '/../vendor/autoload.php';
 
+// 2. Load the .env file
+// It will look for a .env file in the same directory as this config file (backend/api/)
+try {
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+    $dotenv->load();
+} catch (\Dotenv\Exception\InvalidPathException $e) {
+    // This happens if the .env file is not found.
+    // We will handle this gracefully below.
+    // In a web context, you might want to return a 503 Service Unavailable error.
+    die("Error: Could not find the .env file. Please copy .env.example to .env and fill in your credentials.");
+}
+
+
+// 3. Define a helper function to get required env variables
+function get_required_env($key) {
+    if (!isset($_ENV[$key])) {
+        die("Error: Required environment variable '{$key}' is not set in your .env file.");
+    }
+    return $_ENV[$key];
+}
+
+// 4. Define constants from environment variables
+// --- Database Configuration ---
+define('DB_HOST', get_required_env('DB_HOST'));
+define('DB_NAME', get_required_env('DB_NAME'));
+define('DB_USER', get_required_env('DB_USER'));
+define('DB_PASS', get_required_env('DB_PASS'));
 
 // --- Telegram Bot Configuration ---
-define('TELEGRAM_BOT_TOKEN', '7279950407:AAGo');
-define('TELEGRAM_CHANNEL_ID', '-1002652392716');
-define('TELEGRAM_SUPER_ADMIN_ID', 1878794912);
+define('TELEGRAM_BOT_TOKEN', get_required_env('TELEGRAM_BOT_TOKEN'));
+define('TELEGRAM_CHANNEL_ID', get_required_env('TELEGRAM_CHANNEL_ID'));
+define('TELEGRAM_SUPER_ADMIN_ID', get_required_env('TELEGRAM_SUPER_ADMIN_ID'));
 
 ?>

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "vlucas/phpdotenv": "^5.5"
+    }
+}


### PR DESCRIPTION
The existing configuration in `backend/api/config.php` used hardcoded constants for database credentials and bot tokens. This is insecure and makes it impossible to configure the application for different environments, causing the bot to fail on startup.

This change introduces a standard `.env` based configuration system using the `vlucas/phpdotenv` library.

- Adds `backend/composer.json` to manage PHP dependencies.
- Adds `backend/api/.env.example` as a template for users.
- Refactors `backend/api/config.php` to load all secrets from a `.env` file.
- Adds error handling for missing `.env` file or required variables.
- Updates `.gitignore` to exclude the `vendor` directory and local `.env` files.

This resolves the bot startup issue by allowing users to provide their own credentials.