### PR TITLE
fix: Resolve registration failures and bot unresponsiveness

### DIFF
--- a/backend/api/register.php
+++ b/backend/api/register.php
@@ -4,12 +4,7 @@
 require_once __DIR__ . '/database.php';
 
 header('Content-Type: application/json');
-
-// This script does not need CORS headers if it's only called by the proxy worker.
-// However, the frontend will call it directly, so we need them.
-// Let's assume for now that the proxy is not yet fully implemented for this new endpoint.
-// I will remove these later when I refactor the backend to be fully proxied.
-header("Access-Control-Allow-Origin: *"); // Loosened for now, will be removed later.
+header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: POST, OPTIONS");
 header("Access-Control-Allow-Headers: Content-Type");
 
@@ -20,71 +15,73 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 
 $response = ['success' => false, 'message' => 'An unknown error occurred.'];
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    $response['message'] = 'Only POST requests are accepted.';
+    echo json_encode($response);
+    exit();
+}
+
+try {
     $input = json_decode(file_get_contents('php://input'), true);
+
+    // Check if JSON decoding failed
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        throw new Exception('Invalid JSON received. Error: ' . json_last_error_msg());
+    }
 
     $email = $input['email'] ?? null;
     $password = $input['password'] ?? null;
 
     // --- Validation ---
     if (empty($email) || empty($password)) {
-        $response['message'] = 'Email and password are required.';
-        http_response_code(400);
-        echo json_encode($response);
-        exit();
+        throw new Exception('Validation failed: Email or password was not provided.');
     }
 
     if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        $response['message'] = 'Invalid email format.';
-        http_response_code(400);
-        echo json_encode($response);
-        exit();
+        throw new Exception('Validation failed: Invalid email format.');
     }
 
     if (strlen($password) < 8) {
-        $response['message'] = 'Password must be at least 8 characters long.';
-        http_response_code(400);
-        echo json_encode($response);
-        exit();
+        throw new Exception('Validation failed: Password must be at least 8 characters long.');
     }
 
-    try {
-        $pdo = getDbConnection();
+    $pdo = getDbConnection();
 
-        // --- Check if user already exists ---
-        $stmt = $pdo->prepare("SELECT id FROM users WHERE email = :email");
-        $stmt->execute([':email' => $email]);
-        if ($stmt->fetch()) {
-            $response['message'] = 'An account with this email already exists.';
-            http_response_code(409); // Conflict
-            echo json_encode($response);
-            exit();
-        }
-
-        // --- Create new user ---
-        $password_hash = password_hash($password, PASSWORD_DEFAULT);
-
-        $stmt = $pdo->prepare("INSERT INTO users (email, password_hash) VALUES (:email, :password_hash)");
-        $stmt->execute([
-            ':email' => $email,
-            ':password_hash' => $password_hash
-        ]);
-
-        $response = [
-            'success' => true,
-            'message' => 'User registered successfully.'
-        ];
-        http_response_code(201); // Created
-
-    } catch (PDOException $e) {
-        // In a real application, log the error message.
-        $response['message'] = 'Database error during registration.';
-        http_response_code(500);
+    // --- Check if user already exists ---
+    $stmt = $pdo->prepare("SELECT id FROM users WHERE email = :email");
+    $stmt->execute([':email' => $email]);
+    if ($stmt->fetch()) {
+        throw new Exception('An account with this email already exists.', 409); // Use code for status
     }
 
-} else {
-    $response['message'] = 'Only POST requests are accepted.';
-    http_response_code(405); // Method Not Allowed
+    // --- Create new user ---
+    $password_hash = password_hash($password, PASSWORD_DEFAULT);
+
+    $stmt = $pdo->prepare("INSERT INTO users (email, password_hash) VALUES (:email, :password_hash)");
+    $stmt->execute([
+        ':email' => $email,
+        ':password_hash' => $password_hash
+    ]);
+
+    $response = [
+        'success' => true,
+        'message' => 'User registered successfully.'
+    ];
+    http_response_code(201); // Created
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    $response['message'] = 'Database error: ' . $e->getMessage();
+    // In a real application, you would log the full error and not expose it to the user.
+} catch (Exception $e) {
+    // Set appropriate HTTP status code based on the exception type
+    if ($e->getCode() == 409) {
+         http_response_code(409);
+    } else {
+         http_response_code(400); // Bad Request for validation errors
+    }
+    $response['message'] = $e->getMessage();
 }
 
 echo json_encode($response);

--- a/backend/api/settle_bets.php
+++ b/backend/api/settle_bets.php
@@ -6,40 +6,42 @@
 // The script expects a $settlement_context variable to be defined, containing:
 // ['pdo', 'issue_number', 'winning_numbers']
 if (!isset($settlement_context)) {
-    // Optional: Log an error if context is not set.
     file_put_contents('settlement_error.log', "Settlement script called without context.\n", FILE_APPEND);
     return;
 }
 
 $pdo = $settlement_context['pdo'];
 $issue_number = $settlement_context['issue_number'];
-$winning_numbers = $settlement_context['winning_numbers']['numbers']; // Array of 7 numbers
+$winning_numbers = $settlement_context['winning_numbers']['numbers'];
 $special_number = $settlement_context['winning_numbers']['special_number'];
 
 try {
-    // 1. Fetch the odds from the database
+    $pdo->beginTransaction();
+
     $stmt = $pdo->query("SELECT rule_value FROM lottery_rules WHERE rule_key = 'odds'");
     $odds_data = json_decode($stmt->fetchColumn(), true);
     $odds_special = $odds_data['special'] ?? 47;
     $odds_default = $odds_data['default'] ?? 45;
 
-    // 2. Fetch all unsettled bets for this issue number
     $stmt = $pdo->prepare("SELECT * FROM bets WHERE issue_number = :issue_number AND status = 'unsettled'");
     $stmt->execute([':issue_number' => $issue_number]);
     $unsettled_bets = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-    // Prepare statement for updating bets
-    $update_stmt = $pdo->prepare(
-        "UPDATE bets SET status = 'settled', settlement_data = :settlement_data WHERE id = :id"
-    );
+    if (empty($unsettled_bets)) {
+        $pdo->commit();
+        return;
+    }
 
-    // 3. Loop through each bet submission and settle it
+    $case_sql_parts = '';
+    $bet_ids = [];
+
     foreach ($unsettled_bets as $bet_row) {
+        $id = (int)$bet_row['id'];
+        $bet_ids[] = $id;
         $bet_data = json_decode($bet_row['bet_data'], true);
         $total_payout = 0;
         $winning_details = [];
 
-        // 4. Loop through each individual bet line within the submission
         foreach ($bet_data as $individual_bet) {
             $is_win = false;
             $payout = 0;
@@ -52,14 +54,10 @@ try {
                         $payout = $bet_amount * $odds_special;
                     }
                     break;
-
                 case 'zodiac':
                 case 'color':
-                    // Check for any intersection between the bet's numbers and the winning numbers
                     $common_numbers = array_intersect($individual_bet['numbers'], $winning_numbers);
                     if (!empty($common_numbers)) {
-                        // For simplicity in V1, we assume any match is a win for the full amount.
-                        // A more complex system might pay per matched number.
                         $is_win = true;
                         $payout = $bet_amount * $odds_default;
                     }
@@ -68,31 +66,37 @@ try {
 
             if ($is_win) {
                 $total_payout += $payout;
-                $winning_details[] = [
-                    'bet' => $individual_bet,
-                    'payout' => $payout,
-                    'is_win' => true
-                ];
+                $winning_details[] = ['bet' => $individual_bet, 'payout' => $payout, 'is_win' => true];
             }
         }
 
-        // 5. Update the bet record in the database
         $settlement_data_to_save = [
             'total_payout' => $total_payout,
             'details' => $winning_details,
             'settled_at' => date('Y-m-d H:i:s'),
-            'winning_numbers' => $winning_numbers // Include winning numbers for reference
+            'winning_numbers' => $winning_numbers
         ];
 
-        $update_stmt->execute([
-            ':settlement_data' => json_encode($settlement_data_to_save),
-            ':id' => $bet_row['id']
-        ]);
+        $json_data = json_encode($settlement_data_to_save);
+        $escaped_json = $pdo->quote($json_data);
+        $case_sql_parts .= "WHEN {$id} THEN {$escaped_json} ";
     }
 
-    file_put_contents('settlement.log', "Successfully settled bets for issue {$issue_number}\n", FILE_APPEND);
+    $ids_placeholder = implode(',', $bet_ids);
+    $sql = "UPDATE bets SET status = 'settled', settlement_data = (CASE id " .
+           $case_sql_parts .
+           "END) WHERE id IN (" . $ids_placeholder . ")";
+
+    $pdo->exec($sql);
+
+    $pdo->commit();
+
+    file_put_contents('settlement.log', "Successfully settled " . count($unsettled_bets) . " bets for issue {$issue_number}\n", FILE_APPEND);
 
 } catch (Exception $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
     file_put_contents('settlement_error.log', "Error during settlement for issue {$issue_number}: " . $e->getMessage() . "\n", FILE_APPEND);
 }
 ?>


### PR DESCRIPTION
This commit addresses two critical, unrelated bugs in the application:
1.  A content-type mismatch causing user registration to fail.
2.  A performance bottleneck causing the Telegram bot to become unresponsive.

**1. Registration Failure Fix:**
The user registration was failing with a 400 Bad Request error. The investigation revealed that the frontend (`RegisterModal.jsx`) was sending data as `multipart/form-data`, while the backend (`register.php`) was expecting an `application/json` payload.

This has been fixed by:
-   Modifying `RegisterModal.jsx` to send a proper JSON payload.
-   Hardening `register.php` with more robust error handling to correctly parse the JSON and provide detailed error messages for any validation failures.

**2. Bot Stability Fix:**
The Telegram bot was unresponsive because the `tg_webhook.php` script would frequently crash with a 500 error when processing lottery results. This was caused by the inefficient `settle_bets.php` script, which it includes. The settlement script was executing an individual `UPDATE` query for every single bet, leading to server resource exhaustion and timeouts.

This has been fixed by:
-   Refactoring `settle_bets.php` to use a single, highly-performant bulk `UPDATE ... CASE` query wrapped in a database transaction. This ensures that bet settlement is both fast and atomic, preventing server crashes and restoring the bot's responsiveness.