### PR TITLE
chore: Update backend deployment workflow

### DIFF
--- a/.github/workflows/deploy-backend-api.yml
+++ b/.github/workflows/deploy-backend-api.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: Rsync backend directory to serv00
         run: |
-          rsync -avz --mkpath --delete --exclude 'api/config.php' --exclude 'api/.env' -e "ssh -o StrictHostKeyChecking=no" ./backend/ "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}:${{ secrets.SERV00_PATH }}/"
+          rsync -avz --mkpath --delete --exclude 'api/.env' -e "ssh -o StrictHostKeyChecking=no" ./backend/ "${{ secrets.SERV00_USER }}@${{ secrets.SERV00_HOST }}:${{ secrets.SERV00_PATH }}/"


### PR DESCRIPTION
This commit updates the backend deployment workflow to remove the exclusion for the `backend/api/config.php` file.

Following the refactoring to a `.env` based configuration system, the `config.php` file no longer contains sensitive credentials and is now safe to be deployed directly. This change ensures that the file is included in the `rsync` synchronization process.