### PR TITLE
feat: Implement bot settlement and manual draw features

### DIFF
--- a/backend/api/test_settlement.php
+++ b/backend/api/test_settlement.php
@@ -1,0 +1,129 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+require_once __DIR__ . '/tg_webhook_unified.php';
+
+echo "--- Settlement Logic Test Script ---\n\n";
+
+$pdo = getDbConnection();
+
+// Test Data
+$test_issue_number = '2025999';
+$test_lottery_name = 'TestLotto';
+$test_winning_numbers = [1, 2, 3, 4, 5, 6];
+$test_special_number = 7;
+
+// Sample Bets
+$bet1_parsed = [
+    ['type' => 'special', 'number' => 7, 'amount' => 10, 'display_name' => '特码'], // WIN
+    ['type' => 'special', 'number' => 8, 'amount' => 10, 'display_name' => '特码']  // LOSE
+];
+$bet2_parsed = [
+    ['type' => 'zodiac', 'name' => '鸡', 'numbers' => [1, 13, 25, 37, 49], 'amount' => 20, 'display_name' => '生肖'], // WIN (number 1)
+    ['type' => 'color', 'name' => '蓝波', 'numbers' => [3, 4, 9, 10], 'amount' => 30, 'display_name' => '波色'] // WIN (numbers 3, 4)
+];
+$bet3_parsed = [
+    ['type' => 'zodiac', 'name' => '狗', 'numbers' => [10, 22, 34, 46], 'amount' => 50, 'display_name' => '生肖'] // LOSE
+];
+
+// Odds
+$test_odds = ['special' => 47, 'default' => 45];
+$test_zodiacs = ['鸡' => [1, 13, 25, 37, 49], '狗' => [10, 22, 34, 46]];
+$test_colors = ['蓝波' => [3, 4, 9, 10, 15, 16, 21, 22, 27, 28, 32, 33, 38, 39, 44, 45, 50]];
+
+
+function cleanup($pdo, $issue) {
+    echo "Cleaning up test data...\n";
+    $pdo->prepare("DELETE FROM lottery_draws WHERE issue_number = ?")->execute([$issue]);
+    $pdo->prepare("DELETE FROM bets WHERE issue_number = ?")->execute([$issue]);
+    $pdo->prepare("DELETE FROM lottery_rules WHERE rule_key LIKE 'test_%'")->execute();
+    echo "Cleanup complete.\n";
+}
+
+try {
+    // 1. Setup
+    echo "1. Setting up test data...\n";
+    $pdo->beginTransaction();
+
+    // Insert rules
+    $stmt = $pdo->prepare("INSERT INTO lottery_rules (rule_key, rule_value) VALUES (?, ?) ON DUPLICATE KEY UPDATE rule_value = VALUES(rule_value)");
+    $stmt->execute(['odds', json_encode($test_odds)]);
+    $stmt->execute(['zodiac_mappings', json_encode($test_zodiacs)]);
+    $stmt->execute(['color_mappings', json_encode($test_colors)]);
+
+    // Insert draw result
+    $stmt = $pdo->prepare("INSERT INTO lottery_draws (issue_number, lottery_name, numbers, special_number) VALUES (?, ?, ?, ?)");
+    $stmt->execute([$test_issue_number, $test_lottery_name, json_encode($test_winning_numbers), $test_special_number]);
+
+    // Insert bets
+    $stmt = $pdo->prepare("INSERT INTO bets (issue_number, original_content, parsed_data, status) VALUES (?, ?, ?, 'pending')");
+    $stmt->execute([$test_issue_number, 'test content 1', json_encode($bet1_parsed)]);
+    $bet1_id = $pdo->lastInsertId();
+    $stmt->execute([$test_issue_number, 'test content 2', json_encode($bet2_parsed)]);
+    $bet2_id = $pdo->lastInsertId();
+    $stmt->execute([$test_issue_number, 'test content 3', json_encode($bet3_parsed)]);
+    $bet3_id = $pdo->lastInsertId();
+
+    $pdo->commit();
+    echo "Setup complete. Inserted 3 bets with IDs: $bet1_id, $bet2_id, $bet3_id\n\n";
+
+    // 2. Execute
+    echo "2. Executing settleBetsForIssue function...\n";
+    $result_message = settleBetsForIssue($pdo, $test_issue_number);
+    echo "Function returned: \"$result_message\"\n\n";
+
+    // 3. Assert
+    echo "3. Verifying results...\n";
+    $stmt = $pdo->prepare("SELECT * FROM bets WHERE id IN (?, ?, ?)");
+    $stmt->execute([$bet1_id, $bet2_id, $bet3_id]);
+    $settled_bets = $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+    $all_settled = true;
+    $payouts_correct = true;
+
+    // Bet 1: Payout should be 10 * 47 = 470
+    $payout1 = json_decode($settled_bets[$bet1_id]['settlement_data'], true)['total_payout'];
+    if ($settled_bets[$bet1_id]['status'] !== 'settled' || $payout1 != 470) {
+        $payouts_correct = false;
+        echo "FAIL: Bet 1 incorrect. Status: {$settled_bets[$bet1_id]['status']}, Payout: {$payout1} (expected 470)\n";
+    } else {
+        echo "PASS: Bet 1 correct.\n";
+    }
+
+    // Bet 2: Payout should be (20 * 45) + (30 * 45) = 900 + 1350 = 2250
+    $payout2 = json_decode($settled_bets[$bet2_id]['settlement_data'], true)['total_payout'];
+    if ($settled_bets[$bet2_id]['status'] !== 'settled' || $payout2 != 2250) {
+        $payouts_correct = false;
+        echo "FAIL: Bet 2 incorrect. Status: {$settled_bets[$bet2_id]['status']}, Payout: {$payout2} (expected 2250)\n";
+    } else {
+        echo "PASS: Bet 2 correct.\n";
+    }
+
+    // Bet 3: Payout should be 0
+    $payout3 = json_decode($settled_bets[$bet3_id]['settlement_data'], true)['total_payout'];
+    if ($settled_bets[$bet3_id]['status'] !== 'settled' || $payout3 != 0) {
+        $payouts_correct = false;
+        echo "FAIL: Bet 3 incorrect. Status: {$settled_bets[$bet3_id]['status']}, Payout: {$payout3} (expected 0)\n";
+    } else {
+        echo "PASS: Bet 3 correct.\n";
+    }
+
+    echo "\n--- TEST SUMMARY ---\n";
+    if ($payouts_correct) {
+        echo "✅ SUCCESS: All bets were settled with the correct payout amounts.\n";
+    } else {
+        echo "❌ FAILURE: One or more bets had incorrect settlement data.\n";
+    }
+
+} catch (Exception $e) {
+    echo "AN UNEXPECTED ERROR OCCURRED: " . $e->getMessage() . "\n";
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+} finally {
+    // 4. Teardown
+    cleanup($pdo, $test_issue_number);
+}
+
+?>

--- a/backend/api/tg_webhook_unified.php
+++ b/backend/api/tg_webhook_unified.php
@@ -142,7 +142,107 @@ function parseBets(string $inputText, $pdo): array {
     return $bets;
 }
 
-// 6. Telegram API Communication
+// 6. Bet Settlement Logic (from settle_bets.php)
+function settleBetsForIssue($pdo, $issue_number) {
+    try {
+        // First, get the winning numbers for this issue
+        $stmt = $pdo->prepare("SELECT numbers, special_number FROM lottery_draws WHERE issue_number = ?");
+        $stmt->execute([$issue_number]);
+        $draw = $stmt->fetch();
+
+        if (!$draw) {
+            return "结算失败：找不到期号为 `{$issue_number}` 的开奖结果。";
+        }
+
+        $winning_numbers = json_decode($draw['numbers'], true);
+        $special_number = $draw['special_number'];
+
+        // Get odds
+        $stmt = $pdo->query("SELECT rule_value FROM lottery_rules WHERE rule_key = 'odds'");
+        $odds_data = json_decode($stmt->fetchColumn(), true);
+        $odds_special = $odds_data['special'] ?? 47;
+        $odds_default = $odds_data['default'] ?? 45; // A default for zodiac/color if not specified
+
+        // Get all pending bets for this issue
+        $stmt = $pdo->prepare("SELECT * FROM bets WHERE issue_number = ? AND status = 'pending'");
+        $stmt->execute([$issue_number]);
+        $pending_bets = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        if (empty($pending_bets)) {
+            return "无需结算：期号 `{$issue_number}` 没有待处理的投注。";
+        }
+
+        $pdo->beginTransaction();
+
+        $update_stmt = $pdo->prepare("UPDATE bets SET status = 'settled', settlement_data = ? WHERE id = ?");
+        $settled_count = 0;
+        $total_payout_all_bets = 0;
+
+        foreach ($pending_bets as $bet_row) {
+            $parsed_bets = json_decode($bet_row['parsed_data'], true);
+            $bet_total_payout = 0;
+            $winning_details = [];
+
+            foreach ($parsed_bets as $individual_bet) {
+                $is_win = false;
+                $payout = 0;
+                $bet_amount = $individual_bet['amount'];
+
+                switch ($individual_bet['type']) {
+                    case 'special':
+                        if ($individual_bet['number'] == $special_number) {
+                            $is_win = true;
+                            $payout = $bet_amount * $odds_special;
+                        }
+                        break;
+                    case 'zodiac':
+                    case 'color':
+                        $common_numbers = array_intersect($individual_bet['numbers'], $winning_numbers);
+                        if (!empty($common_numbers)) {
+                            $is_win = true;
+                            $payout = $bet_amount * $odds_default;
+                        }
+                        break;
+                }
+
+                if ($is_win) {
+                    $bet_total_payout += $payout;
+                    $winning_details[] = ['bet' => $individual_bet, 'payout' => $payout, 'is_win' => true];
+                }
+            }
+
+            // Only update if there was a payout
+            if ($bet_total_payout > 0) {
+                 $total_payout_all_bets += $bet_total_payout;
+            }
+
+            $settlement_data_to_save = json_encode([
+                'total_payout' => $bet_total_payout,
+                'details' => $winning_details,
+                'settled_at' => date('Y-m-d H:i:s'),
+                'winning_numbers' => $winning_numbers,
+                'special_number' => $special_number
+            ]);
+
+            $update_stmt->execute([$settlement_data_to_save, $bet_row['id']]);
+            $settled_count++;
+        }
+
+        $pdo->commit();
+
+        return "结算完成！\n期号: `$issue_number`\n- 处理了 `{$settled_count}` 条投注。\n- 总赔付金额: `{$total_payout_all_bets}`。";
+
+    } catch (Exception $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        log_error("Error during settlement for issue {$issue_number}: " . $e->getMessage());
+        return "结算时发生严重错误。请检查日志。";
+    }
+}
+
+
+// 7. Telegram API Communication
 function sendMessage($chatId, $text, $keyboard = null) {
     $url = 'https://api.telegram.org/bot' . TELEGRAM_BOT_TOKEN . '/sendMessage';
     $post_fields = [
@@ -208,10 +308,10 @@ if (isset($update['callback_query'])) {
             $message = "您点击了“解析最新投注”按钮。请直接发送需要解析的投注文本。";
             break;
         case 'settle_bets':
-            $message = "您点击了“结算投注”按钮。此功能待实现。";
+            $message = "请回复 `/settle [期号]` 来结算指定期数的投注。\n例如: `/settle 2025101`";
             break;
         case 'manual_draw':
-            $message = "您点击了“手动开奖”按钮。此功能待实现。";
+            $message = "请回复 `/draw [名称] [号码]` 来手动录入开奖结果。\n例如: `/draw 新澳门六合彩 1,2,3,4,5,6,7`";
             break;
     }
     answerCallbackQuery($callbackId); // Acknowledge the tap
@@ -266,6 +366,58 @@ if (strpos($text, '/start') === 0) {
     $stmt->execute([$issueNumber, $betContent, json_encode($parsedBets)]);
 
     sendMessage($chatId, "投注解析成功并已保存！\n期号: `$issueNumber`\n共解析出 `" . count($parsedBets) . "` 条投注。");
+
+} elseif (strpos($text, '/settle') === 0) {
+    $parts = explode(' ', $text, 2);
+    if (count($parts) < 2 || !is_numeric($parts[1])) {
+        sendMessage($chatId, "格式错误。用法: `/settle [期号]`");
+        exit();
+    }
+    $issueNumber = trim($parts[1]);
+
+    // Show a "processing" message
+    sendMessage($chatId, "正在结算期号 `{$issueNumber}`，请稍候...");
+
+    $result_message = settleBetsForIssue($pdo, $issueNumber);
+    sendMessage($chatId, $result_message);
+
+} elseif (strpos($text, '/draw') === 0) {
+    $parts = explode(' ', $text, 3);
+    if (count($parts) < 3) {
+        sendMessage($chatId, "格式错误。用法: `/draw [开奖名称] [号码,用逗号隔开]`\n例如: `/draw 新澳门六合彩 1,2,3,4,5,6,7`");
+        exit();
+    }
+    $lotteryName = trim($parts[1]);
+    $numbersStr = trim($parts[2]);
+    $numbers = array_map('trim', explode(',', $numbersStr));
+
+    if (count($numbers) < 7) {
+        sendMessage($chatId, "号码错误：必须提供至少7个号码。");
+        exit();
+    }
+
+    // The last number is the special number
+    $special_number = array_pop($numbers);
+    // The rest are the main numbers
+    $main_numbers = $numbers;
+
+    // Use the current date as the issue number
+    $issueNumber = date('Ymd');
+
+    try {
+        $stmt = $pdo->prepare("INSERT INTO lottery_draws (issue_number, lottery_name, numbers, special_number, draw_time) VALUES (?, ?, ?, ?, NOW())");
+        $stmt->execute([$issueNumber, $lotteryName, json_encode($main_numbers), $special_number]);
+
+        sendMessage($chatId, "开奖结果已手动保存！\n期号: `$issueNumber`\n名称: `$lotteryName`\n号码: `" . implode(', ', $main_numbers) . "`\n特别号: `$special_number`");
+
+        // Automatically trigger settlement for this new draw
+        $settle_message = settleBetsForIssue($pdo, $issueNumber);
+        sendMessage($chatId, $settle_message);
+
+    } catch (Exception $e) {
+        log_error("Manual draw error: " . $e->getMessage());
+        sendMessage($chatId, "保存开奖结果时发生错误。");
+    }
 
 } else {
     // Default behavior for any other text: assume it's a bet to be parsed


### PR DESCRIPTION
This commit adds new functionality to the Telegram bot to allow the admin to settle bets and manually enter lottery results.

Key changes:

1.  **Bet Settlement Logic:**
    -   A new function, `settleBetsForIssue`, has been added to the unified webhook script.
    -   This function calculates and saves settlement data for all pending bets for a given issue number.

2.  **`/settle` Command:**
    -   A new `/settle [issue_number]` command has been added to the bot.
    -   This command allows the admin to trigger the settlement process manually.
    -   The 'Settle Bets' inline keyboard button has been updated to provide instructions for this command.

3.  **Manual Draw Logic:**
    -   A new `/draw [name] [numbers]` command has been added to the bot.
    -   This allows the admin to manually record the results of a lottery draw.
    -   The command automatically uses the current date as the issue number and triggers the settlement process for the new draw.
    -   The 'Manual Draw' inline keyboard button has been updated with instructions.