### PR TITLE
feat: Add frontend .env.example file

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+# The base URL of your backend API.
+# If you are using the Cloudflare proxy worker (recommended), you can leave this blank.
+# The application will then make relative API calls (e.g., /api/login.php), which the
+# worker running on the same domain will intercept and forward to the backend.
+#
+# If you are not using the proxy worker, set this to the full public URL of your backend.
+# e.g., VITE_API_BASE_URL=https://your-backend-domain.com
+VITE_API_BASE_URL=


### PR DESCRIPTION
This commit introduces a `.env.example` file for the frontend application.

This file serves as a template for developers, documenting the necessary environment variables (like `VITE_API_BASE_URL`) required to configure the frontend. It includes comments explaining how to set the variables for different deployment scenarios (e.g., when using the Cloudflare proxy worker).

This improves the project's documentation and makes the setup process easier for new developers.