### PR TITLE
Fix registration error and improve frontend robustness

### DIFF
--- a/frontend/src/components/RegisterModal.jsx
+++ b/frontend/src/components/RegisterModal.jsx
@@ -21,7 +21,14 @@ const RegisterModal = ({ onClose, onRegisterSuccess }) => {
         const payload = { email, password };
 
         try {
-            const apiUrl = `${import.meta.env.VITE_API_BASE_URL || ''}/api/register.php`;
+            const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+            if (!apiBaseUrl) {
+                console.error("FATAL: VITE_API_BASE_URL is not defined. API calls will fail. Please check your .env file in the /frontend directory.");
+                setError("Application is not configured correctly. Please contact support.");
+                setLoading(false);
+                return;
+            }
+            const apiUrl = `${apiBaseUrl}/api/register.php`;
             // Axios automatically serializes the object to JSON and sets the correct Content-Type header.
             const response = await axios.post(apiUrl, payload);
 
@@ -63,6 +70,7 @@ const RegisterModal = ({ onClose, onRegisterSuccess }) => {
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
                             required
+                            autoComplete="new-password"
                         />
                     </div>
                     <div className="form-group">
@@ -73,6 +81,7 @@ const RegisterModal = ({ onClose, onRegisterSuccess }) => {
                             value={confirmPassword}
                             onChange={(e) => setConfirmPassword(e.target.value)}
                             required
+                            autoComplete="new-password"
                         />
                     </div>
                     <button type="submit" disabled={loading}>


### PR DESCRIPTION
This commit addresses a "405 Method Not Allowed" error occurring during user registration.

The root cause was identified as a missing `VITE_API_BASE_URL` environment variable in the frontend build environment. This caused the frontend to make API calls to its own domain instead of the backend API, leading to the error.

The following changes were made:
- **Improved Frontend Error Handling:** The `RegisterModal.jsx` component was updated to check for the presence of `VITE_API_BASE_URL`. If the variable is missing, it now logs a detailed error to the console for developers and shows a user-friendly error message, preventing silent failure.
- **Improved Form Usability:** Added `autocomplete="new-password"` to the password fields in the registration form to comply with browser best practices and improve user experience.