### PR TITLE
fix: Correct backend host URL in Cloudflare Worker

### DIFF
--- a/frontend/public/_worker.js
+++ b/frontend/public/_worker.js
@@ -11,7 +11,7 @@
  */
 export default {
   async fetch(request, env, ctx) {
-    const backendHost = 'https://9522.ip-ddns.com';
+    const backendHost = 'https://wenge.cloudns.ch';
     const url = new URL(request.url);
 
     // --------- 1. 处理 API 代理 ---------


### PR DESCRIPTION
This commit corrects the hardcoded `backendHost` variable in the `frontend/public/_worker.js` script.

The previous URL was incorrect, causing `404 Not Found` errors as the worker was proxying requests to the wrong server. The URL has been updated to `https://wenge.cloudns.ch` as specified by the user.

This should be the final change required to make the application fully functional with the new proxy architecture.