### PR TITLE
fix(api): Add CORS headers to auth endpoints

### DIFF
--- a/backend/check_session.php
+++ b/backend/check_session.php
@@ -1,4 +1,15 @@
 <?php
+// CORS Headers
+header("Access-Control-Allow-Origin: https://ss.wenxiuxiu.eu.org");
+header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+
+// Handle preflight OPTIONS request
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    exit(0);
+}
+
 session_start();
 
 header('Content-Type: application/json');

--- a/backend/login.php
+++ b/backend/login.php
@@ -1,4 +1,15 @@
 <?php
+// CORS Headers
+header("Access-Control-Allow-Origin: https://ss.wenxiuxiu.eu.org");
+header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+
+// Handle preflight OPTIONS request
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    exit(0);
+}
+
 // 1. Start Session
 session_start();
 

--- a/backend/logout.php
+++ b/backend/logout.php
@@ -1,4 +1,15 @@
 <?php
+// CORS Headers
+header("Access-Control-Allow-Origin: https://ss.wenxiuxiu.eu.org");
+header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+
+// Handle preflight OPTIONS request
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    exit(0);
+}
+
 session_start();
 
 // Unset all of the session variables

--- a/backend/register.php
+++ b/backend/register.php
@@ -1,4 +1,15 @@
 <?php
+// CORS Headers
+header("Access-Control-Allow-Origin: https://ss.wenxiuxiu.eu.org");
+header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
+header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+
+// Handle preflight OPTIONS request
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    exit(0);
+}
+
 // 1. Include Configuration
 require_once __DIR__ . '/config.php';
 


### PR DESCRIPTION
Adds the necessary CORS (Cross-Origin Resource Sharing) headers to the PHP authentication scripts (`login.php`, `register.php`, `check_session.php`, `logout.php`).

This is required to allow the frontend, served from a different domain (`ss.wenxiuxiu.eu.org`), to make API calls to the backend.

The changes include:
- Setting `Access-Control-Allow-Origin` to the specific frontend domain.
- Setting `Access-Control-Allow-Credentials` to `true` to support sessions.
- Setting `Access-Control-Allow-Headers` and `Access-Control-Allow-Methods`.
- Handling preflight `OPTIONS` requests.