### PR TITLE
fix(api): Remove incorrect CORS headers

### DIFF
--- a/backend/check_session.php
+++ b/backend/check_session.php
@@ -1,15 +1,4 @@
 <?php
-// CORS Headers
-header("Access-Control-Allow-Origin: https://ss.wenxiuxiu.eu.org");
-header("Access-Control-Allow-Credentials: true");
-header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
-header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
-
-// Handle preflight OPTIONS request
-if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
-    exit(0);
-}
-
 session_start();
 
 header('Content-Type: application/json');

--- a/backend/login.php
+++ b/backend/login.php
@@ -1,15 +1,4 @@
 <?php
-// CORS Headers
-header("Access-Control-Allow-Origin: https://ss.wenxiuxiu.eu.org");
-header("Access-Control-Allow-Credentials: true");
-header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
-header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
-
-// Handle preflight OPTIONS request
-if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
-    exit(0);
-}
-
 // 1. Start Session
 session_start();
 

--- a/backend/logout.php
+++ b/backend/logout.php
@@ -1,15 +1,4 @@
 <?php
-// CORS Headers
-header("Access-Control-Allow-Origin: https://ss.wenxiuxiu.eu.org");
-header("Access-Control-Allow-Credentials: true");
-header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
-header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
-
-// Handle preflight OPTIONS request
-if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
-    exit(0);
-}
-
 session_start();
 
 // Unset all of the session variables

--- a/backend/register.php
+++ b/backend/register.php
@@ -1,15 +1,4 @@
 <?php
-// CORS Headers
-header("Access-Control-Allow-Origin: https://ss.wenxiuxiu.eu.org");
-header("Access-Control-Allow-Credentials: true");
-header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With");
-header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
-
-// Handle preflight OPTIONS request
-if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
-    exit(0);
-}
-
 // 1. Include Configuration
 require_once __DIR__ . '/config.php';
 


### PR DESCRIPTION
Reverts the manual CORS headers added to the PHP authentication scripts.

Based on user feedback, the application uses a service worker (`_worker.js`) to proxy API requests and handle cross-domain issues. Therefore, the CORS headers on the PHP scripts themselves are unnecessary and incorrect for this architecture.