### PR TITLE
feat: Save parsed lottery results to database

### DIFF
--- a/backend/data_table_schema.sql
+++ b/backend/data_table_schema.sql
@@ -1,5 +1,28 @@
--- This SQL script creates the table for storing parsed lottery results.
--- The bot should be modified to save the parsed data into this table.
+-- =================================================================
+--  Database Schema for the Application
+-- =================================================================
+
+--
+-- Table structure for table `users`
+-- This table stores user information for the web application.
+--
+
+CREATE TABLE IF NOT EXISTS `users` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `username` VARCHAR(255) NOT NULL UNIQUE,
+  `email` VARCHAR(255) NOT NULL UNIQUE,
+  `password` VARCHAR(255) NOT NULL,
+  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- =================================================================
+
+
+--
+-- Table structure for table `lottery_results`
+-- This table stores parsed lottery results from the Telegram bot.
+--
 
 CREATE TABLE IF NOT EXISTS `lottery_results` (
   `id` INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
Implements the functionality to save parsed lottery results from the Telegram bot into the `lottery_results` table in the database.

A new function, `saveLotteryResultToDB`, is added to `backend/tg_webhook.php` to handle the SQL `INSERT ... ON DUPLICATE KEY UPDATE` logic. The main webhook process is updated to call this function and report the detailed outcome to the admin, replacing the old file-based logging.

refactor: Consolidate and correct database schema

In response to user feedback, the SQL table definitions for both `users` and `lottery_results` have been consolidated into `backend/data_table_schema.sql`.

The `users` table schema was also corrected to enforce `username` as `NOT NULL`, aligning with the application's registration process.