### PR TITLE
feat: Display lottery results from bot on frontend

### DIFF
--- a/backend/actions/get_lottery_results.php
+++ b/backend/actions/get_lottery_results.php
@@ -1,0 +1,20 @@
+<?php
+// Action: Get all lottery results
+
+try {
+    // The $pdo variable is inherited from index.php
+    $sql = "SELECT lottery_name, issue_number, numbers, parsed_at FROM lottery_results ORDER BY id DESC";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute();
+
+    $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    http_response_code(200);
+    echo json_encode(['success' => true, 'results' => $results]);
+
+} catch (PDOException $e) {
+    error_log("Get Lottery Results DB query error: " . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Failed to retrieve lottery results.']);
+}
+?>

--- a/backend/tg_webhook.php
+++ b/backend/tg_webhook.php
@@ -90,6 +90,39 @@ function listUsersFromDB($pdo) {
 }
 
 /**
+ * Saves a parsed lottery result to the database.
+ *
+ * @param PDO $pdo The database connection object.
+ * @param array $result The parsed result array from LotteryParser.
+ * @return string A status message indicating the outcome.
+ */
+function saveLotteryResultToDB($pdo, $result) {
+    $numbers_str = implode(',', $result['numbers']);
+    $sql = "INSERT INTO lottery_results (lottery_name, issue_number, numbers)
+            VALUES (:lottery_name, :issue_number, :numbers)
+            ON DUPLICATE KEY UPDATE numbers = VALUES(numbers), parsed_at = CURRENT_TIMESTAMP";
+    try {
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute([
+            ':lottery_name' => $result['lottery_name'],
+            ':issue_number' => $result['issue_number'],
+            ':numbers' => $numbers_str
+        ]);
+        $rowCount = $stmt->rowCount();
+        if ($rowCount === 1) {
+            return "新开奖结果已成功存入数据库。";
+        } elseif ($rowCount >= 1) { // 2 for update on some drivers
+            return "开奖结果已在数据库中更新。";
+        } else {
+            return "开奖结果与数据库记录一致，未作更改。";
+        }
+    } catch (PDOException $e) {
+        error_log("Database error saving lottery result: " . $e->getMessage());
+        return "保存开奖结果时出错。";
+    }
+}
+
+/**
  * Analyzes a given text and returns a formatted report.
  * @param string $text The text to analyze.
  * @return string The analysis report.
@@ -134,13 +167,15 @@ if (isset($update['message'])) {
     $parsedResult = LotteryParser::parse($text);
 
     if ($parsedResult) {
-        // If parsing is successful, log the result.
-        // Later, this will be saved to the database.
-        $logMessage = "Parsed Lottery Result: " . json_encode($parsedResult, JSON_UNESCAPED_UNICODE);
-        file_put_contents('webhook_log.txt', $logMessage . "\n", FILE_APPEND);
-        // Optionally, send a confirmation back to the admin
+        // If parsing is successful, save the result to the database.
+        $statusMessage = saveLotteryResultToDB($pdo, $parsedResult);
+
+        // Send a confirmation back to the admin with the status.
         if ($chat_id === $admin_id) {
-            sendMessage($chat_id, "成功识别到开奖结果：\n" . $parsedResult['lottery_name'] . " - " . $parsedResult['issue_number']);
+            $responseText = "成功识别到开奖结果：\n"
+                          . "`" . $parsedResult['lottery_name'] . " - " . $parsedResult['issue_number'] . "`\n\n"
+                          . "状态: *" . $statusMessage . "*";
+            sendMessage($chat_id, $responseText);
         }
     } else {
         // If it's not a lottery result, process it as a command

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -13,6 +13,7 @@ function MainLayout() {
         <nav>
           <Link to="/">邮件处理器</Link>
           <Link to="/bills">我的账单</Link>
+          <Link to="/lottery-results">开奖记录</Link>
         </nav>
         <div className="user-info">
           {user && <span>欢迎, {user.email}</span>}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,7 +7,8 @@ import {
 import App from './App.jsx'
 import LoginPage from './pages/LoginPage.jsx';
 import RegisterPage from './pages/RegisterPage.jsx';
-import BillsPage from './pages/BillsPage.jsx'; // Import the new page
+import BillsPage from './pages/BillsPage.jsx';
+import LotteryResultsPage from './pages/LotteryResultsPage.jsx'; // Import the new page
 import ProtectedRoute from './components/ProtectedRoute.jsx';
 import MainLayout from './components/MainLayout.jsx'; // Import the new layout
 import { AuthProvider } from './context/AuthContext.jsx';
@@ -28,6 +29,10 @@ const router = createBrowserRouter([
       {
         path: "/bills",
         element: <BillsPage />,
+      },
+      {
+        path: "/lottery-results",
+        element: <LotteryResultsPage />,
       }
     ]
   },

--- a/frontend/src/pages/LotteryResultsPage.jsx
+++ b/frontend/src/pages/LotteryResultsPage.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react';
+
+function LotteryResultsPage() {
+  const [results, setResults] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchResults = async () => {
+      setIsLoading(true);
+      setError('');
+      try {
+        const response = await fetch('/api/get_lottery_results');
+        const data = await response.json();
+
+        if (data.success) {
+          setResults(data.results);
+        } else {
+          setError(data.error || 'Failed to fetch lottery results.');
+        }
+      } catch (err) {
+        setError('An error occurred while fetching results. Please try again later.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchResults();
+  }, []); // Fetch only once on component mount
+
+  if (isLoading) {
+    return <div>正在加载开奖记录...</div>;
+  }
+
+  if (error) {
+    return <div className="error">{error}</div>;
+  }
+
+  return (
+    <div className="bills-container">
+      <h2>开奖记录</h2>
+      {results.length === 0 ? (
+        <p>还没有任何开奖记录。</p>
+      ) : (
+        <table className="bills-table">
+          <thead>
+            <tr>
+              <th>开奖名称</th>
+              <th>期号</th>
+              <th>开奖号码</th>
+              <th>录入时间</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((result, index) => (
+              <tr key={index}>
+                <td>{result.lottery_name}</td>
+                <td>{result.issue_number}</td>
+                <td>{result.numbers}</td>
+                <td>{new Date(result.parsed_at).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+export default LotteryResultsPage;


### PR DESCRIPTION
This commit implements a full-stack feature to automatically save and display lottery results.

- **Backend:**
  - The Telegram webhook (`tg_webhook.php`) has been updated to save parsed lottery results directly to the `lottery_results` database table.
  - A new API endpoint (`actions/get_lottery_results.php`) has been created to fetch all saved results.

- **Frontend:**
  - A new page (`LotteryResultsPage.jsx`) has been created to display the lottery results in a table.
  - The main layout and router have been updated to include a navigation link to the new "Lottery Results" page.