### PR TITLE
feat: Add styled lottery results page

### DIFF
--- a/backend/actions/get_game_data.php
+++ b/backend/actions/get_game_data.php
@@ -1,0 +1,19 @@
+<?php
+// Action: Get static game data (e.g., color maps)
+
+// The GameData library is already included by the index.php router
+// but for clarity and potential standalone use, we can include it again.
+require_once __DIR__ . '/../lib/GameData.php';
+
+try {
+    // We only need the color map for this feature
+    $colorMap = GameData::$colorMap;
+
+    http_response_code(200);
+    echo json_encode(['success' => true, 'colorMap' => $colorMap]);
+
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Failed to retrieve game data.']);
+}
+?>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -65,3 +65,46 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+/* Lottery Results Page Styles */
+.lottery-group {
+  margin-bottom: 2rem;
+  width: 100%;
+}
+.lottery-group h3 {
+  border-bottom: 2px solid #444;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+.number-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 5px 0;
+}
+.number-ball {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  line-height: 32px;
+  text-align: center;
+  border-radius: 50%;
+  color: white;
+  font-weight: bold;
+  font-size: 14px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+.number-ball-red {
+  background-color: #e74c3c;
+}
+.number-ball-blue {
+  background-color: #3498db;
+}
+.number-ball-green {
+  background-color: #2ecc71;
+}
+.number-ball-default {
+  background-color: #95a5a6;
+}


### PR DESCRIPTION
This commit implements a full-stack feature to automatically save and display lottery results.

- **Backend:**
  - The `tg_webhook.php` script has been updated to save parsed lottery results directly to the `lottery_results` database table.
  - A new API endpoint (`actions/get_lottery_results.php`) has been created to fetch all saved results.
  - A new API endpoint (`actions/get_game_data.php`) exposes the static color map data to the frontend.

- **Frontend:**
  - A new page (`LotteryResultsPage.jsx`) has been created to display the lottery results in a table.
  - The page fetches both the results and the color map data.
  - It groups results by lottery name and displays each number in a "ball" element.
  - The background color of each ball is styled with CSS according to its "color wave" (red, blue, or green).
  - A navigation link to the new page has been added to the main layout.