### PR TITLE
feat: Enhance lottery results page layout and styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -67,10 +67,6 @@ button:focus-visible {
 }
 
 /* Lottery Results Page Styles */
-.lottery-group {
-  margin-bottom: 2rem;
-  width: 100%;
-}
 .lottery-group h3 {
   border-bottom: 2px solid #444;
   padding-bottom: 0.5rem;
@@ -107,4 +103,15 @@ button:focus-visible {
 }
 .number-ball-default {
   background-color: #95a5a6;
+}
+.special-number {
+  margin-left: 15px; /* Adds space before the special number */
+}
+.lottery-group {
+  width: 100%;
+  margin-bottom: 2rem;
+  padding: 1rem;
+  border: 1px solid #444;
+  border-radius: 8px;
+  background-color: var(--card-background-color);
 }

--- a/frontend/src/pages/LotteryResultsPage.jsx
+++ b/frontend/src/pages/LotteryResultsPage.jsx
@@ -100,8 +100,8 @@ function LotteryResultsPage() {
                 <td>{result.lottery_name}</td>
                 <td>{result.issue_number}</td>
                 <td className="number-cell">
-                  {result.numbers.split(',').map(num => (
-                    <span key={num} className={getNumberColorClass(num)}>
+                  {result.numbers.split(',').map((num, idx) => (
+                    <span key={num} className={`${getNumberColorClass(num)} ${idx === 6 ? 'special-number' : ''}`}>
                       {num}
                     </span>
                   ))}


### PR DESCRIPTION
This commit refines the UI of the "Lottery Results" page based on user feedback.

- **Layout:** Results are now grouped into distinct visual "banners" for each lottery type, improving readability.
- **Styling:**
  - The 7th number in each result set is now identified as a "special number" and is visually separated from the afirst 6 regular numbers with extra spacing.
  - Added CSS to make the "banner" for each lottery group more distinct.