### PR TITLE
debug: Add submitted email to registration error message

### DIFF
--- a/frontend/src/components/AuthModal.jsx
+++ b/frontend/src/components/AuthModal.jsx
@@ -46,7 +46,8 @@ function AuthModal({ onClose }) {
         setSuccessMessage('注册成功！请登录。');
         setIsLoginView(true); // Switch to login view
       } else {
-        setError(data.error || '注册失败。');
+        const errorMessage = data.error || '注册失败。';
+        setError(`为邮箱 [${email}] 注册失败：${errorMessage}`);
       }
     } catch (err) {
       setError('发生错误，请重试。');


### PR DESCRIPTION
This commit modifies the registration form to include the submitted email address in the error message when a registration fails.

This is a temporary debugging measure to help diagnose an issue where users are reporting "user already exists" errors even for new email addresses. This will make it clear what email the frontend is actually sending to the backend.