### PR TITLE
debug: Dump raw input in register script

### DIFF
--- a/backend/actions/register.php
+++ b/backend/actions/register.php
@@ -7,7 +7,27 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit();
 }
 
-$data = json_decode(file_get_contents("php://input"), true);
+$input = file_get_contents("php://input");
+$data = json_decode($input, true);
+
+// --- AGGRESSIVE DEBUGGING ---
+// We will stop the script here to see exactly what data is being received.
+header('Content-Type: text/plain; charset=utf-8'); // Ensure plain text for readability
+echo "--- DEBUG OUTPUT ---";
+echo "\n\n";
+echo "Raw Input Stream:\n";
+print_r($input);
+echo "\n\n";
+echo "json_decode() Result:\n";
+print_r($data);
+echo "\n\n";
+echo "Email from decoded data:\n";
+print_r($data['email'] ?? 'NOT SET');
+echo "\n\n";
+echo "--- END DEBUG ---";
+exit();
+// --- END AGGRESSIVE DEBUGGING ---
+
 
 if (!isset($data['email']) || !filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
     http_response_code(400);


### PR DESCRIPTION
This is a temporary commit for aggressive debugging.

The `register.php` script has been modified to halt execution and print the raw data it receives from the frontend. This is to diagnose a persistent "user already exists" error by allowing the user to see the exact data that the backend is processing.

This commit must be reverted after the bug is identified.