### PR TITLE
fix(worker): Remove custom port from backend host URL

### DIFF
--- a/frontend/public/_worker.js
+++ b/frontend/public/_worker.js
@@ -1,6 +1,6 @@
 export default {
   async fetch(request, env, ctx) {
-    const backendHost = 'https://wenge.cloudns.ch:10758';
+    const backendHost = 'https://wenge.cloudns.ch';
     const url = new URL(request.url);
 
     // Check if the request is for a static asset. If not, proxy to the API backend.


### PR DESCRIPTION
Based on user feedback, the custom port `:10758` has been removed from the `backendHost` constant in `_worker.js`.

The configuration is now reverted to use the default HTTPS port (443).