### PR TITLE
fix: Remove /api prefix from all frontend API calls

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -10,7 +10,7 @@ export function AuthProvider({ children }) {
     // Check session on initial load
     const verifySession = async () => {
       try {
-        const response = await fetch('/api/check_session');
+        const response = await fetch('/check_session');
         const data = await response.json();
         if (data.isAuthenticated) {
           setUser(data.user);
@@ -29,7 +29,7 @@ export function AuthProvider({ children }) {
   };
 
   const logout = async () => {
-    await fetch('/api/logout');
+    await fetch('/logout');
     setUser(null);
   };
 

--- a/frontend/src/hooks/useLotteryData.jsx
+++ b/frontend/src/hooks/useLotteryData.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 
-export function useLotteryData({ apiPrefix = '' } = {}) {
+export function useLotteryData() {
   const [results, setResults] = useState([]);
   const [colorMap, setColorMap] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -12,8 +12,8 @@ export function useLotteryData({ apiPrefix = '' } = {}) {
       setError('');
       try {
         const [resultsResponse, gameDataResponse] = await Promise.all([
-          fetch(`${apiPrefix}/get_lottery_results`),
-          fetch(`${apiPrefix}/get_game_data`)
+          fetch('/get_lottery_results'),
+          fetch('/get_game_data')
         ]);
 
         const resultsData = await resultsResponse.json();

--- a/frontend/src/pages/BillsPage.jsx
+++ b/frontend/src/pages/BillsPage.jsx
@@ -12,7 +12,7 @@ function BillsPage() {
       setIsLoading(true);
       setError('');
       try {
-        const response = await fetch('/api/get_bills', {
+        const response = await fetch('/get_bills', {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',

--- a/frontend/src/pages/LotteryResultsPage.jsx
+++ b/frontend/src/pages/LotteryResultsPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useLotteryData } from '../hooks/useLotteryData';
 
 function LotteryResultsPage() {
-  const { results, isLoading, error, getNumberColorClass } = useLotteryData({ apiPrefix: '/api' });
+  const { results, isLoading, error, getNumberColorClass } = useLotteryData();
 
   const groupedResults = results.reduce((acc, result) => {
     const key = result.lottery_name;


### PR DESCRIPTION
The `/api` prefix in frontend fetch calls was causing CORS and 500 errors, as the backend is not configured to handle it.

This change removes the `/api` prefix from all API calls in the following files:
- `frontend/src/context/AuthContext.jsx`
- `frontend/src/pages/BillsPage.jsx`
- `frontend/src/hooks/useLotteryData.jsx`

This also completes the refactoring of the lottery data fetching logic into the `useLotteryData` custom hook, which is now used by `App.jsx` and `LotteryResultsPage.jsx`.