### PR TITLE
fix: Correctly handle POST body in worker

### DIFF
--- a/frontend/public/_worker.js
+++ b/frontend/public/_worker.js
@@ -56,7 +56,7 @@ export default {
       };
 
       if (request.method !== 'GET' && request.method !== 'HEAD') {
-        init.body = request.body;
+        init.body = await request.clone().arrayBuffer();
       }
 
       let backendResp;


### PR DESCRIPTION
A recent change to the `_worker.js` script broke the handling of POST request bodies by incorrectly assigning `request.body` (a ReadableStream) to the proxied request's body.

This commit reverts that change and restores the use of `await request.clone().arrayBuffer()`. This method correctly reads the entire request body into an ArrayBuffer, which can then be properly processed by the backend PHP script.

This fixes the `401 Unauthorized` error that was occurring during login.