### PR TITLE
fix: Include raw_content in get_bills API

### DIFF
--- a/backend/actions/get_bills.php
+++ b/backend/actions/get_bills.php
@@ -10,7 +10,7 @@ $user_id = $_SESSION['user_id'];
 
 try {
     // The $pdo variable is inherited from index.php
-    $sql = "SELECT id, total_cost, status, created_at, settlement_details FROM bills WHERE user_id = :user_id ORDER BY created_at DESC";
+    $sql = "SELECT id, raw_content, total_cost, status, created_at, settlement_details FROM bills WHERE user_id = :user_id ORDER BY created_at DESC";
     $stmt = $pdo->prepare($sql);
     $stmt->execute([':user_id' => $user_id]);
 


### PR DESCRIPTION
The `get_bills` API endpoint was not selecting the `raw_content` column from the `bills` table. This resulted in the 'original email content' panel on the 'My Bills' page being empty.

This commit updates the SQL query in `get_bills.php` to include the `raw_content` column, ensuring that the frontend receives all the necessary data to display the bill details correctly.