### PR TITLE
fix(css): Adjust lottery banner styles for mobile

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -262,3 +262,26 @@ a:hover {
   font-size: inherit;
   cursor: pointer;
 }
+
+/* Responsive adjustments for mobile */
+@media (max-width: 768px) {
+  #root {
+    padding: 1rem;
+  }
+  main {
+    padding: 1.5rem;
+  }
+  .lottery-banner {
+    padding: 1rem 1.5rem;
+  }
+  .lottery-banner h3 {
+    font-size: 1.1em;
+  }
+  .banner-numbers .number-ball {
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
+    font-size: 1em;
+    margin: 2px;
+  }
+}


### PR DESCRIPTION
The lottery results banner was too large on mobile devices, leading to a poor user experience.

This commit adds a media query to `App.css` for screens up to 768px wide. Inside this query, the following adjustments have been made:
- Reduced padding on the `.lottery-banner`.
- Reduced font size for the banner's `h3` element.
- Reduced the width, height, line-height, font-size, and margin of the `.number-ball` within the banner.

These changes make the banner more compact and usable on mobile devices.