### PR TITLE
fix: Convert email content to UTF-8 on upload

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -23,6 +23,12 @@ $user_email = $_POST['user_email'];
 $file_tmp_path = $_FILES['chat_file']['tmp_name'];
 $raw_content = file_get_contents($file_tmp_path);
 
+// Detect and convert encoding to UTF-8 to prevent garbled text
+$encoding = mb_detect_encoding($raw_content, mb_detect_order(), true);
+if ($encoding && $encoding !== 'UTF-8') {
+    $raw_content = mb_convert_encoding($raw_content, 'UTF-8', $encoding);
+}
+
 if ($raw_content === false) {
     http_response_code(500);
     echo json_encode(['success' => false, 'error' => 'Could not read uploaded file.']);


### PR DESCRIPTION
Resolves an issue where email content was displayed with garbled characters due to non-UTF-8 encoding.

The `email_upload.php` script now uses `mb_detect_encoding` to determine the character set of the uploaded file content and `mb_convert_encoding` to convert it to UTF-8 if necessary.

This ensures that all `raw_content` stored in the database is in the correct UTF-8 format, preventing garbled text when displayed on the frontend.