### PR TITLE
feat: Make header navigation context-aware

### DIFF
--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Outlet, NavLink } from 'react-router-dom';
+import { Outlet, NavLink, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import AuthModal from './AuthModal';
 import '../App.css';
@@ -7,6 +7,7 @@ import '../App.css';
 function MainLayout() {
   const { isAuthenticated, logout } = useAuth();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const location = useLocation();
 
   return (
     <div className="container">
@@ -20,7 +21,9 @@ function MainLayout() {
         </div>
         <div className="header-right">
           {isAuthenticated && (
-            <NavLink to="/bills" className="header-link">我的账单</NavLink>
+            location.pathname === '/bills'
+              ? <NavLink to="/" className="header-link">返回主页</NavLink>
+              : <NavLink to="/bills" className="header-link">我的账单</NavLink>
           )}
         </div>
       </header>

--- a/frontend/src/pages/BillsPage.jsx
+++ b/frontend/src/pages/BillsPage.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 // Component to render the structured settlement details
@@ -142,7 +141,6 @@ function BillsPage() {
 
   return (
     <div className="bills-container">
-      <Link to="/" className="back-link">&larr; 返回主页</Link>
       <h2>我的账单</h2>
       {bills.length === 0 ? (
         <p>您还没有任何账单记录。</p>


### PR DESCRIPTION
This commit refactors the main header navigation to be dynamic based on the current route.

- The `useLocation` hook is now used in `MainLayout.jsx` to determine the current path.
- The navigation link to the 'My Bills' page now conditionally renders its text and destination. It shows 'My Bills' (links to /bills) on all pages except the bills page, where it shows 'Back to Home' (links to /).
- The static 'Back to Home' link on the `BillsPage.jsx` has been removed to avoid redundancy.

This creates a cleaner and more intuitive user experience.