### PR TITLE
fix: Add robust handling for character encoding

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -24,7 +24,7 @@ $file_tmp_path = $_FILES['chat_file']['tmp_name'];
 $raw_content = file_get_contents($file_tmp_path);
 
 // Detect and convert encoding to UTF-8 to prevent garbled text
-$encoding = mb_detect_encoding($raw_content, mb_detect_order(), true);
+$encoding = mb_detect_encoding($raw_content, ['UTF-8', 'GBK', 'GB2312', 'BIG5'], true);
 if ($encoding && $encoding !== 'UTF-8') {
     $raw_content = mb_convert_encoding($raw_content, 'UTF-8', $encoding);
 }

--- a/backend/index.php
+++ b/backend/index.php
@@ -35,7 +35,7 @@ require_once __DIR__ . '/config.php';
 
 // 2. Database Connection (passed to action scripts)
 try {
-    $pdo = new PDO("mysql:host=$db_host;dbname=$db_name;charset=utf8", $db_user, $db_pass);
+    $pdo = new PDO("mysql:host=$db_host;dbname=$db_name;charset=utf8mb4", $db_user, $db_pass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
     error_log("DB connection error in router: " . $e->getMessage());


### PR DESCRIPTION
This commit provides a more robust, two-part solution to fix an issue with garbled characters in processed emails.

1.  **Update DB Connection Charset:** The PDO DSN in `index.php` is updated from `charset=utf8` to `charset=utf8mb4`. This ensures full Unicode compatibility with the database schema and prevents potential data truncation or incorrect storage of 4-byte UTF-8 characters.

2.  **Improve Encoding Detection:** The `email_upload.php` script is updated to use a specific list of common Chinese encodings (`['UTF-8', 'GBK', 'GB2312', 'BIG5']`) for `mb_detect_encoding`. This is more reliable than relying on the default detection order and improves the accuracy of converting the source email content to UTF-8.