### PR TITLE
fix: Force utf8mb4 on PDO connection

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -37,6 +37,7 @@ require_once __DIR__ . '/config.php';
 try {
     $pdo = new PDO("mysql:host=$db_host;dbname=$db_name;charset=utf8mb4", $db_user, $db_pass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $pdo->exec("SET NAMES 'utf8mb4'");
 } catch (PDOException $e) {
     error_log("DB connection error in router: " . $e->getMessage());
     http_response_code(500);


### PR DESCRIPTION
Resolves a persistent character encoding issue ('mojibake') by making the database connection handling more robust.

Even with `charset=utf8mb4` in the DSN, encoding mismatches can still occur depending on the server configuration. This commit adds `$pdo->exec("SET NAMES 'utf8mb4'");` right after the PDO connection is established in `index.php`.

This command ensures that all subsequent communication with the database uses the `utf8mb4` character set, which should permanently resolve the garbled text problem for all new records.