### PR TITLE
fix: Register /delete_bill route in worker

### DIFF
--- a/frontend/public/_worker.js
+++ b/frontend/public/_worker.js
@@ -9,6 +9,7 @@ export default {
       '/check_session',
       '/email_upload',
       '/get_bills',
+      '/delete_bill',
       '/get_game_data',
       '/get_lottery_results',
       '/is_user_registered',


### PR DESCRIPTION
The `/delete_bill` API endpoint was not being proxied to the backend because it was missing from the `apiRoutes` list in the `_worker.js` script. This caused the delete functionality to fail with a generic network error on the frontend.

This commit adds `/delete_bill` to the `apiRoutes` array, allowing the worker to correctly identify and handle requests to this endpoint.