### PR TITLE
debug: Add version to error message

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -18,7 +18,7 @@ if (!isset($_POST['worker_secret']) || $_POST['worker_secret'] !== $worker_secre
 // Validate required fields
 if (!isset($_POST['user_email']) || !isset($_POST['charset']) || !isset($_FILES['email_part_file'])) {
     http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'Missing required fields from worker.']);
+    echo json_encode(['success' => false, 'error' => 'Missing required fields from worker (v2).']);
     exit();
 }
 if ($_FILES['email_part_file']['error'] !== UPLOAD_ERR_OK) {


### PR DESCRIPTION
To help diagnose a persistent issue where the server appears to be running an old version of a file, this commit adds a version marker `(v2)` to a specific error message in the `email_upload.php` script.

This will allow for definitive confirmation of whether the user's deployment of the latest code is successful.