### PR TITLE
debug: Add specific error messages

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -16,9 +16,19 @@ if (!isset($_POST['worker_secret']) || $_POST['worker_secret'] !== $worker_secre
 }
 
 // Validate required fields
-if (!isset($_POST['user_email']) || !isset($_POST['charset']) || !isset($_FILES['email_part_file'])) {
+if (!isset($_POST['user_email'])) {
     http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'Missing required fields from worker (v2).']);
+    echo json_encode(['success' => false, 'error' => 'Missing required field: user_email']);
+    exit();
+}
+if (!isset($_POST['charset'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing required field: charset']);
+    exit();
+}
+if (!isset($_FILES['email_part_file'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing required file: email_part_file']);
     exit();
 }
 if ($_FILES['email_part_file']['error'] !== UPLOAD_ERR_OK) {


### PR DESCRIPTION
To further diagnose a `400 Bad Request` error, this commit updates the validation logic in `email_upload.php`.

Instead of a generic "Missing required fields" error, the script now checks for each required field (`user_email`, `charset`, `email_part_file`) individually. If a field is missing, the API will now return a specific error message (e.g., "Missing required field: user_email").

This will allow for precise identification of the data that is not being correctly sent by the Cloudflare worker.