### PR TITLE
fix: Rearchitect to use PHP-side MIME parsing

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -1,7 +1,82 @@
 <?php
-// Action: Handle raw email part upload from the Cloudflare worker
+// Action: Handle RAW email upload from the Cloudflare worker and parse it
 
 require_once __DIR__ . '/../lib/BetCalculator.php';
+
+/**
+ * A simple MIME parser to extract the plain text body from a raw email.
+ *
+ * @param string $raw_email The full raw email content.
+ * @return string|null The decoded, UTF-8 converted plain text body, or null if not found.
+ */
+function get_plain_text_body_from_email($raw_email) {
+    // Find the main boundary
+    if (!preg_match('/boundary="?([^"]+)"?/i', $raw_email, $matches)) {
+        // Not a multipart email, or boundary not found. Assume the body is plain text.
+        // This is a fallback and might not be perfect.
+        $bodyPos = strpos($raw_email, "\r\n\r\n");
+        if ($bodyPos !== false) {
+            return mb_convert_encoding(substr($raw_email, $bodyPos + 4), 'UTF-8', 'auto');
+        }
+        return mb_convert_encoding($raw_email, 'UTF-8', 'auto');
+    }
+    $boundary = $matches[1];
+
+    // Split the email into parts
+    $parts = explode('--' . $boundary, $raw_email);
+    array_shift($parts); // Remove the part before the first boundary
+
+    foreach ($parts as $part) {
+        if (trim($part) == '--') continue; // End boundary
+
+        // We only care about the plain text part that is not an attachment
+        if (stripos($part, 'Content-Type: text/plain') !== false && stripos($part, 'Content-Disposition: attachment') === false) {
+
+            // Separate headers from the body
+            $header_part = '';
+            $body_part = '';
+            $split_pos = strpos($part, "\r\n\r\n");
+            if ($split_pos !== false) {
+                $header_part = substr($part, 0, $split_pos);
+                $body_part = substr($part, $split_pos + 4);
+            } else {
+                continue; // Malformed part
+            }
+
+            // Get transfer encoding and charset from the part's headers
+            $transfer_encoding = '7bit';
+            if (preg_match('/Content-Transfer-Encoding:\s*(\S+)/i', $header_part, $encoding_matches)) {
+                $transfer_encoding = strtolower($encoding_matches[1]);
+            }
+            $charset = 'UTF-8';
+            if (preg_match('/charset="?([^"]+)"?/i', $header_part, $charset_matches)) {
+                $charset = strtoupper($charset_matches[1]);
+            }
+
+            // Decode the body
+            $decoded_body = '';
+            switch ($transfer_encoding) {
+                case 'base64':
+                    $decoded_body = base64_decode($body_part);
+                    break;
+                case 'quoted-printable':
+                    $decoded_body = quoted_printable_decode($body_part);
+                    break;
+                default:
+                    $decoded_body = $body_part;
+                    break;
+            }
+
+            // Convert to UTF-8 and return
+            return mb_convert_encoding($decoded_body, 'UTF-8', $charset);
+        }
+    }
+
+    return null; // No suitable plain text part found
+}
+
+
+// Main script logic starts here
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     http_response_code(405);
@@ -14,46 +89,35 @@ if (!isset($_POST['worker_secret']) || $_POST['worker_secret'] !== $worker_secre
     echo json_encode(['success' => false, 'error' => 'Access denied.']);
     exit();
 }
-
-// Validate required fields
-if (!isset($_POST['user_email'])) {
+if (!isset($_POST['user_email']) || !isset($_FILES['raw_email_file'])) {
     http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'Missing required field: user_email']);
+    echo json_encode(['success' => false, 'error' => 'Missing required fields from worker.']);
     exit();
 }
-if (!isset($_POST['charset'])) {
-    http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'Missing required field: charset']);
-    exit();
-}
-if (!isset($_FILES['email_part_file'])) {
-    http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'Missing required file: email_part_file']);
-    exit();
-}
-if ($_FILES['email_part_file']['error'] !== UPLOAD_ERR_OK) {
+if ($_FILES['raw_email_file']['error'] !== UPLOAD_ERR_OK) {
     http_response_code(400);
     echo json_encode(['success' => false, 'error' => 'File upload error from worker.']);
     exit();
 }
 
 $user_email = $_POST['user_email'];
-$charset = $_POST['charset'];
-$file_tmp_path = $_FILES['email_part_file']['tmp_name'];
+$file_tmp_path = $_FILES['raw_email_file']['tmp_name'];
+$raw_email_content = file_get_contents($file_tmp_path);
 
-// 1. Read the raw bytes from the uploaded file part
-$raw_body_bytes = file_get_contents($file_tmp_path);
-if ($raw_body_bytes === false) {
+if ($raw_email_content === false) {
     http_response_code(500);
-    echo json_encode(['success' => false, 'error' => 'Could not read uploaded email part file.']);
+    echo json_encode(['success' => false, 'error' => 'Could not read uploaded email file.']);
     exit();
 }
 
-// 2. Convert the character encoding of the raw bytes to UTF-8
-// This is the most reliable step, as PHP has strong tools for this.
-$raw_content = mb_convert_encoding($raw_body_bytes, 'UTF-8', $charset);
+// Use our new parser to get the clean, UTF-8 content
+$raw_content = get_plain_text_body_from_email($raw_email_content);
 
-// 3. Find user
+if ($raw_content === null) {
+    $raw_content = "Error: Could not find a suitable text/plain part in the email.";
+}
+
+// The rest of the script is the same as before
 $stmt = $pdo->prepare("SELECT id FROM users WHERE email = :email");
 $stmt->execute([':email' => $user_email]);
 $user = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -65,7 +129,6 @@ if (!$user) {
 }
 $user_id = $user['id'];
 
-// 4. Process content with BetCalculator
 $settlement_slip = BetCalculator::calculate($raw_content);
 
 $status = 'unrecognized';
@@ -78,7 +141,6 @@ if ($settlement_slip !== null) {
     $total_cost = $settlement_slip['summary']['total_cost'];
 }
 
-// 5. Save the bill to the database
 try {
     $sql = "INSERT INTO bills (user_id, raw_content, settlement_details, total_cost, status)
             VALUES (:user_id, :raw_content, :settlement_details, :total_cost, :status)";

--- a/frontend/worker/email_handler.js
+++ b/frontend/worker/email_handler.js
@@ -1,83 +1,4 @@
-// worker/email_handler.js (Ultimate Edition: Raw Buffer Parsing)
-
-// ========== 辅助函数区域 ==========
-
-// 将 ReadableStream 转为 ArrayBuffer
-async function streamToArrayBuffer(stream) {
-    let result = new Uint8Array(0);
-    const reader = stream.getReader();
-    while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        const newResult = new Uint8Array(result.length + value.length);
-        newResult.set(result);
-        newResult.set(value, result.length);
-        result = newResult;
-    }
-    return result.buffer;
-}
-
-// 在 Uint8Array 中查找子数组
-function findNeedle(haystack, needle, offset = 0) {
-    for (let i = offset; i <= haystack.length - needle.length; i++) {
-        let found = true;
-        for (let j = 0; j < needle.length; j++) {
-            if (haystack[i + j] !== needle[j]) {
-                found = false;
-                break;
-            }
-        }
-        if (found) return i;
-    }
-    return -1;
-}
-
-function parseEmail(rawBuffer) {
-    const rawUint8 = new Uint8Array(rawBuffer);
-    const textDecoder = new TextDecoder(); // for headers
-    const headersPart = textDecoder.decode(rawUint8.slice(0, 1024));
-
-    const boundaryMatch = headersPart.match(/boundary="?([^"]+)"?/i);
-    if (!boundaryMatch) return null;
-
-    const boundary = `--${boundaryMatch[1]}`;
-    const boundaryBytes = new TextEncoder().encode(boundary);
-
-    let parts = [];
-    let lastPos = 0;
-    while(lastPos < rawUint8.length) {
-        let start = findNeedle(rawUint8, boundaryBytes, lastPos);
-        if (start === -1) break;
-        start += boundaryBytes.length;
-        let end = findNeedle(rawUint8, boundaryBytes, start);
-        if (end === -1) end = rawUint8.length;
-        parts.push(rawUint8.slice(start, end));
-        lastPos = end;
-    }
-
-    for (const part of parts) {
-        const partStr = textDecoder.decode(part);
-        const headersMatch = partStr.match(/^([\s\S]*?)\r?\n\r?\n/);
-        if (!headersMatch) continue;
-
-        const headers = headersMatch[1];
-        const contentTypeHeader = headers.match(/Content-Type:\s*text\/plain/i);
-        const contentDispositionHeader = headers.match(/Content-Disposition:\s*attachment/i);
-
-        if (contentTypeHeader && !contentDispositionHeader) {
-            const bodyOffset = headers.length + 2; // +2 for \r\n
-            const bodyBytes = part.slice(bodyOffset);
-
-            const charsetMatch = headers.match(/charset="?([^"]+)"?/i);
-            const charset = charsetMatch ? charsetMatch[1].trim() : 'utf-8';
-
-            return { raw_body_bytes: bodyBytes, charset: charset };
-        }
-    }
-    return null;
-}
-
-// ========== 核心处理逻辑 ==========
+// worker/email_handler.js (Final Version: PHP handles all parsing)
 
 export default {
   async email(message, env, ctx) {
@@ -85,32 +6,56 @@ export default {
     const WORKER_SECRET = "816429fb-1649-4e48-9288-7629893311a6";
 
     const senderEmail = message.from;
-    if (!senderEmail) { return; }
+    if (!senderEmail) {
+      console.error("Email received without a sender address.");
+      return;
+    }
 
+    // 1. Verify user is registered before proceeding
     try {
       const verificationUrl = `${PUBLIC_API_ENDPOINT}/is_user_registered?worker_secret=${WORKER_SECRET}&email=${encodeURIComponent(senderEmail)}`;
       const verificationResponse = await fetch(verificationUrl);
-      if (!verificationResponse.ok) { return; }
+      if (!verificationResponse.ok) {
+        console.error(`User verification request failed with status: ${verificationResponse.status}`);
+        return;
+      }
       const verificationData = await verificationResponse.json();
-      if (!verificationData.success || !verificationData.is_registered) { return; }
-    } catch (error) { return; }
-
-    try {
-      const rawEmailBuffer = await streamToArrayBuffer(message.raw);
-      const emailPart = parseEmail(rawEmailBuffer);
-
-      if (emailPart) {
-        const formData = new FormData();
-        formData.append("worker_secret", WORKER_SECRET);
-        formData.append("user_email", senderEmail);
-        formData.append("charset", emailPart.charset);
-        formData.append("email_part_file", new Blob([emailPart.raw_body_bytes]), "email_part.txt");
-
-        const uploadUrl = `${PUBLIC_API_ENDPOINT}/email_upload`;
-        await fetch(uploadUrl, { method: "POST", body: formData });
+      if (!verificationData.success || !verificationData.is_registered) {
+        console.log(`Email from unregistered user '${senderEmail}' was rejected by the backend.`);
+        return;
       }
     } catch (error) {
-      console.error("Failed to process/forward email: " + error.message);
+      console.error("Failed to execute user verification fetch: " + error.message);
+      return;
+    }
+
+    // 2. Forward the entire raw email as a file to the backend
+    try {
+      const rawEmailBlob = await message.raw.blob();
+      if (rawEmailBlob.size === 0) {
+        console.error("Email has an empty raw body.");
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append("worker_secret", WORKER_SECRET);
+      formData.append("user_email", senderEmail);
+      formData.append("raw_email_file", rawEmailBlob, "email.eml");
+
+      const uploadUrl = `${PUBLIC_API_ENDPOINT}/email_upload`;
+      const uploadResponse = await fetch(uploadUrl, {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!uploadResponse.ok) {
+          const errorText = await uploadResponse.text();
+          console.error(`Backend upload returned an error: ${uploadResponse.status} ${uploadResponse.statusText}`, errorText);
+      } else {
+          console.log(`Successfully forwarded raw email from ${senderEmail} to the backend for parsing.`);
+      }
+    } catch (error) {
+      console.error("Failed to forward the raw email to the backend: " + error.message);
     }
   },
 };


### PR DESCRIPTION
To definitively solve persistent character encoding issues, this commit re-architects the email processing flow. All complex parsing and decoding logic is now handled by the more robust PHP backend.

- `frontend/worker/email_handler.js`:
  - The worker has been simplified. It no longer performs any parsing.
  - It now forwards the entire raw email as a single file (`raw_email_file`) to the backend.

- `backend/actions/email_upload.php`:
  - The script has been completely rewritten to handle the raw email file.
  - It now includes a new `get_plain_text_body_from_email` function which acts as a simple MIME parser.
  - This function finds the `text/plain` part of the email, decodes its `Content-Transfer-Encoding` (base64, quoted-printable), and converts the content to UTF-8 from the specified `charset`.
  - This clean, UTF-8 content is then used for processing.

This new architecture is the most robust solution to the encoding problems.