### PR TITLE
fix: Correctly split slips with multiline regex

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -165,8 +165,9 @@ $attachments_meta = handle_attachments($user_id);
 
 // Use a regex to split the text by a line that looks like a sender/timestamp delimiter.
 // This pattern looks for a line that ends with HH:MM time format, preceded by a space.
+// The 'm' flag is crucial for making '^' and '$' match the start/end of each line, not just the whole string.
 // The (?=...) is a positive lookahead to keep the delimiter as part of the next split.
-$blocks = preg_split('/(\r\n|\n|\r)(?=.*\s\d{2}:\d{2}$)/', $text_body, -1, PREG_SPLIT_NO_EMPTY);
+$blocks = preg_split('/(\r\n|\n|\r)(?=.*\s\d{2}:\d{2}$)/m', $text_body, -1, PREG_SPLIT_NO_EMPTY);
 
 $slips = [];
 foreach ($blocks as $block) {


### PR DESCRIPTION
This commit fixes a bug in the email parsing logic where the regular expression failed to split content by all sender/timestamp lines.

- Added the multiline (`m`) flag to the regex in `backend/actions/email_upload.php`.
- This ensures that the `$` anchor matches the end of each line, not just the end of the string, allowing the regex to identify all timestamp delimiters correctly.
- This change enables the system to accurately parse emails containing multiple betting slips, each separated by a sender/timestamp line.