### PR TITLE
feat: Implement full manual and automatic settlement system

### DIFF
--- a/backend/actions/auto_settle_slip.php
+++ b/backend/actions/auto_settle_slip.php
@@ -1,0 +1,97 @@
+<?php
+require_once __DIR__ . '/../lib/SettlementCalculator.php';
+
+// Action: Automatically settles a single slip within a bill and updates it.
+
+// Ensure the user is authenticated.
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'User not authenticated.']);
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Only POST method is allowed.']);
+    exit();
+}
+
+$data = json_decode(file_get_contents("php://input"), true);
+
+if (!isset($data['bill_id']) || !isset($data['slip_index'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Invalid input. Missing bill_id or slip_index.']);
+    exit();
+}
+
+$bill_id = $data['bill_id'];
+$slip_index = $data['slip_index'];
+$user_id = $_SESSION['user_id'];
+
+try {
+    // The $pdo variable is inherited from index.php
+
+    // 1. Verify the user owns this bill and get the current details
+    $stmt = $pdo->prepare("SELECT settlement_details FROM bills WHERE id = :bill_id AND user_id = :user_id");
+    $stmt->execute([':bill_id' => $bill_id, ':user_id' => $user_id]);
+    $bill = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$bill) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Bill not found or you do not have permission to edit it.']);
+        exit();
+    }
+
+    $settlement_details = json_decode($bill['settlement_details'], true);
+
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($settlement_details) || !isset($settlement_details[$slip_index])) {
+         http_response_code(500);
+         echo json_encode(['success' => false, 'error' => 'Could not parse existing settlement details or invalid slip index.']);
+         exit();
+    }
+
+    $raw_slip_text = $settlement_details[$slip_index]['raw'];
+
+    // 2. Get the latest lottery result
+    $lottery_stmt = $pdo->query("SELECT numbers, issue_number FROM lottery_results ORDER BY parsed_at DESC LIMIT 1");
+    $latest_result_raw = $lottery_stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$latest_result_raw) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'No lottery results found in the database.']);
+        exit();
+    }
+
+    // The numbers string is "01,02,03,04,05,06,07", with the last being special.
+    $numbers_array = explode(',', $latest_result_raw['numbers']);
+    $special_number = array_pop($numbers_array);
+    $lottery_result = [
+        'numbers' => $numbers_array,
+        'special' => $special_number,
+        'issue_number' => $latest_result_raw['issue_number']
+    ];
+
+    // 3. Call the SettlementCalculator
+    $settlement_text = SettlementCalculator::settle($raw_slip_text, $lottery_result);
+    $settlement_text_with_issue = "根据第 {$lottery_result['issue_number']} 期开奖结果：\n" . $settlement_text;
+
+    // 4. Update the settlement text for the specific slip
+    $settlement_details[$slip_index]['settlement'] = $settlement_text_with_issue;
+    $new_settlement_details_json = json_encode($settlement_details, JSON_UNESCAPED_UNICODE);
+
+    // 5. Save the updated JSON back to the database
+    $update_stmt = $pdo->prepare("UPDATE bills SET settlement_details = :settlement_details WHERE id = :bill_id");
+    $update_stmt->execute([
+        ':settlement_details' => $new_settlement_details_json,
+        ':bill_id' => $bill_id
+    ]);
+
+    http_response_code(200);
+    echo json_encode(['success' => true, 'message' => 'Auto-settlement successful.']);
+
+} catch (PDOException $e) {
+    error_log("Auto-settle DB error: " . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'A server error occurred during auto-settlement.']);
+}
+?>

--- a/backend/lib/SettlementCalculator.php
+++ b/backend/lib/SettlementCalculator.php
@@ -1,0 +1,106 @@
+<?php
+require_once __DIR__ . '/GameData.php';
+
+class SettlementCalculator {
+
+    // NOTE: Odds are hardcoded for now. These should ideally be configurable.
+    private const NORMAL_ODDS = 40;
+    private const SPECIAL_ODDS = 45;
+
+    /**
+     * Settles a raw betting slip against a given lottery result.
+     *
+     * @param string $raw_slip_text The raw text of the betting slip.
+     * @param array|null $lottery_result The lottery result, e.g., ['numbers' => [...], 'special' => '...'].
+     * @return string The formatted settlement result text.
+     */
+    public static function settle(string $raw_slip_text, ?array $lottery_result): string {
+        $parsed_bets = self::parse_slip($raw_slip_text);
+
+        if (empty($parsed_bets['bets'])) {
+            return "无法解析下注单或无有效投注。";
+        }
+
+        if ($lottery_result === null) {
+            return "无法找到对应的开奖结果，无法结算。";
+        }
+
+        $winning_numbers = $lottery_result['numbers'];
+        $special_number = $lottery_result['special'];
+
+        $total_payout = 0;
+        $total_cost = $parsed_bets['total_cost'];
+        $result_details = [];
+
+        foreach ($parsed_bets['bets'] as $bet) {
+            if (in_array($bet['number'], $winning_numbers)) {
+                $payout = $bet['cost'] * self::NORMAL_ODDS;
+                $total_payout += $payout;
+                $result_details[] = "号码 {$bet['number']} 中普通码，赢 {$payout}元 (成本 {$bet['cost']}元)";
+            } elseif ($bet['number'] == $special_number) {
+                $payout = $bet['cost'] * self::SPECIAL_ODDS;
+                $total_payout += $payout;
+                $result_details[] = "号码 {$bet['number']} 中特码，赢 {$payout}元 (成本 {$bet['cost']}元)";
+            }
+        }
+
+        $net_win_loss = $total_payout - $total_cost;
+
+        $output = "--- 结算详情 ---\n";
+        if (empty($result_details)) {
+            $output .= "所有号码均未中奖。\n";
+        } else {
+            $output .= implode("\n", $result_details) . "\n";
+        }
+        $output .= "-----------------\n";
+        $output .= "总投注: {$total_cost}元\n";
+        $output .= "总派彩: {$total_payout}元\n";
+        $output .= "总输赢: " . ($net_win_loss >= 0 ? "赢 " : "输 ") . abs($net_win_loss) . "元";
+
+        return $output;
+    }
+
+    /**
+     * Parses a raw slip text into a list of individual number bets.
+     *
+     * @param string $text The raw text of the betting slip.
+     * @return array An array containing all bets and the total cost.
+     */
+    private static function parse_slip(string $text): array {
+        $all_bets = [];
+
+        // Pattern 1: Zodiacs (e.g., 蛇猪鸡各数5#)
+        preg_match_all('/([\p{Han}]+)各数(\d+)/u', $text, $zodiac_matches, PREG_SET_ORDER);
+        foreach ($zodiac_matches as $match) {
+            $zodiacs_str = $match[1];
+            $cost_per_number = (int)$match[2];
+            $zodiacs = mb_str_split($zodiacs_str);
+            foreach ($zodiacs as $zodiac) {
+                if (isset(GameData::$zodiacMap[$zodiac])) {
+                    foreach (GameData::$zodiacMap[$zodiac] as $number) {
+                        $all_bets[] = ['number' => $number, 'cost' => $cost_per_number];
+                    }
+                }
+            }
+        }
+
+        // Pattern 2: Numbers (e.g., 17,29,35各10 or 12.24.36各5块 or 01,13,25各5#)
+        preg_match_all('/([0-9,.\s]+)(?:各|各数)(\d+)(?:#|块|元)?/u', $text, $number_matches, PREG_SET_ORDER);
+        foreach ($number_matches as $match) {
+            // Clean up the string to only contain numbers and valid separators.
+            $numbers_str = preg_replace('/[^\d,.]/', '', $match[1]);
+            $numbers = preg_split('/[,.]/', $numbers_str, -1, PREG_SPLIT_NO_EMPTY);
+            $cost_per_number = (int)$match[2];
+            foreach ($numbers as $number) {
+                // Pad with leading zero to ensure consistent format (e.g., '4' -> '04')
+                $num_val = str_pad(trim($number), 2, '0', STR_PAD_LEFT);
+                $all_bets[] = ['number' => $num_val, 'cost' => $cost_per_number];
+            }
+        }
+
+        $total_cost = array_sum(array_column($all_bets, 'cost'));
+
+        return ['bets' => $all_bets, 'total_cost' => $total_cost];
+    }
+}
+?>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -187,6 +187,13 @@ a:hover {
   font-size: 0.9em;
   margin-top: 0.5rem;
 }
+
+.success-text {
+  color: var(--success-color);
+  font-size: 0.9em;
+  font-weight: bold;
+  margin-top: 0.5rem;
+}
 .lottery-banner h3 {
   margin: 0 0 1rem 0;
   font-size: 1.2em;


### PR DESCRIPTION
This commit delivers a comprehensive feature set for processing and settling betting slips from emails.

- Implemented a robust email splitting logic in `email_upload.php` that uses sender/timestamp lines as delimiters to accurately handle multi-line slips.
- Created a new `SettlementCalculator.php` library to parse raw bet text and calculate win/loss outcomes against lottery results.
- Added a new `auto_settle_slip.php` endpoint to trigger the automatic settlement for a specific slip.
- Added a new `update_settlement.php` endpoint to allow for manual editing of settlement text.
- Overhauled the `BillsPage.jsx` frontend to display each slip individually.
- Added "Auto Settle" and "Modify/Save" buttons to the UI, providing a full-featured interface for managing settlements.
- Ensured the new UI is fully responsive for mobile devices.