### PR TITLE
fix: Correct API routing and finalize settlement features

### DIFF
--- a/backend/actions/auto_settle_slip.php
+++ b/backend/actions/auto_settle_slip.php
@@ -1,4 +1,6 @@
 <?php
+file_put_contents(__DIR__ . '/debug_log.txt', "--- auto_settle_slip.php started ---\n", FILE_APPEND);
+
 require_once __DIR__ . '/../lib/SettlementCalculator.php';
 
 // Action: Automatically settles a single slip within a bill and updates it.

--- a/frontend/src/pages/BillsPage.jsx
+++ b/frontend/src/pages/BillsPage.jsx
@@ -14,7 +14,7 @@ function SlipItem({ slip, index, billId, onBillUpdate }) {
     setSettleSuccess(false);
     setIsSettling(true);
     try {
-      const response = await fetch('/auto_settle_slip', {
+      const response = await fetch('/?action=auto_settle_slip', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -44,7 +44,7 @@ function SlipItem({ slip, index, billId, onBillUpdate }) {
   const handleSave = async () => {
     setError('');
     try {
-      const response = await fetch('/update_settlement', {
+      const response = await fetch('/?action=update_settlement', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -149,7 +149,7 @@ function BillsPage() {
     setIsLoading(true);
     setError('');
     try {
-      const response = await fetch('/get_bills', {
+      const response = await fetch('/?action=get_bills', {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include'
@@ -196,7 +196,7 @@ function BillsPage() {
       return;
     }
     try {
-      const response = await fetch('/delete_bill', {
+      const response = await fetch('/?action=delete_bill', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ bill_id: billId }),


### PR DESCRIPTION
This commit fixes a critical bug where the frontend was calling incorrect API URLs, and completes the implementation of the manual and automatic settlement system.

- Corrected all `fetch` call URLs in `frontend/src/pages/BillsPage.jsx` to use the `/?action=` format required by the backend router. This fixes the 'get_bills', 'delete_bill', 'auto_settle_slip', and 'update_settlement' actions.
- The `auto_settle_slip.php` action and `SettlementCalculator.php` library are now correctly implemented and reachable by the frontend.
- The `recalculate_total.php` action was added to allow for recalculating the total cost of a bill from the manually entered settlement texts.
- The email splitting logic in `email_upload.php` is now robust, correctly preserving the sender/timestamp line with its content.