### PR TITLE
feat: Implement final, stable manual settlement system

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -1,5 +1,4 @@
 <?php
-require_once __DIR__ . '/../lib/BetCalculator.php';
 
 // Helper: Save attachments to disk and return their metadata
 function handle_attachments($user_id) {
@@ -164,18 +163,20 @@ if (isset($_FILES['html_body']) && $_FILES['html_body']['error'] === UPLOAD_ERR_
 
 $attachments_meta = handle_attachments($user_id);
 
-// 多段结算
-$multi_slip = BetCalculator::calculateMulti($text_body);
-$status = 'unrecognized';
-$settlement_details = null;
+// Use a simple split by blank lines for now.
+$slips_raw = preg_split('/(\r\n|\n|\r)\s*(\r\n|\n|\r)/', $text_body, -1, PREG_SPLIT_NO_EMPTY);
+
+// Map the raw slips to the new object structure.
+$slips = array_map(function($slip) {
+    return [
+        'raw' => trim($slip),
+        'settlement' => '' // Initialize with an empty settlement
+    ];
+}, $slips_raw);
+
+$status = 'pending_settlement';
+$settlement_details = json_encode($slips, JSON_UNESCAPED_UNICODE);
 $total_cost = null;
-if ($multi_slip !== null) {
-    $status = 'processed';
-    $settlement_details = json_encode($multi_slip, JSON_UNESCAPED_UNICODE);
-    $total_cost = array_sum(array_map(function($item) {
-        return $item['result']['summary']['total_cost'] ?? 0;
-    }, $multi_slip));
-}
 
 try {
     $sql = "INSERT INTO bills (user_id, raw_content, settlement_details, total_cost, status)

--- a/backend/actions/update_settlement.php
+++ b/backend/actions/update_settlement.php
@@ -1,0 +1,80 @@
+<?php
+// Action: Update the settlement text for a single slip within a bill.
+
+// Ensure the user is authenticated. The session is started in index.php.
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'User not authenticated.']);
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Only POST method is allowed.']);
+    exit();
+}
+
+$data = json_decode(file_get_contents("php://input"), true);
+
+if (!isset($data['bill_id']) || !isset($data['slip_index']) || !isset($data['settlement_text'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Invalid input. Missing bill_id, slip_index, or settlement_text.']);
+    exit();
+}
+
+$bill_id = $data['bill_id'];
+$slip_index = $data['slip_index'];
+$settlement_text = $data['settlement_text'];
+$user_id = $_SESSION['user_id'];
+
+try {
+    // The $pdo variable is inherited from index.php
+
+    // First, verify the user owns this bill and get the current details
+    $stmt = $pdo->prepare("SELECT settlement_details FROM bills WHERE id = :bill_id AND user_id = :user_id");
+    $stmt->execute([':bill_id' => $bill_id, ':user_id' => $user_id]);
+    $bill = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$bill) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'error' => 'Bill not found or you do not have permission to edit it.']);
+        exit();
+    }
+
+    $settlement_details = json_decode($bill['settlement_details'], true);
+
+    if (json_last_error() !== JSON_ERROR_NONE || !is_array($settlement_details)) {
+         http_response_code(500);
+         echo json_encode(['success' => false, 'error' => 'Could not parse existing settlement details.']);
+         exit();
+    }
+
+    // Check if the slip index is valid
+    if (!isset($settlement_details[$slip_index])) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Invalid slip index.']);
+        exit();
+    }
+
+    // Update the settlement text for the specific slip
+    $settlement_details[$slip_index]['settlement'] = $settlement_text;
+
+    // Encode the updated array back to JSON
+    $new_settlement_details_json = json_encode($settlement_details, JSON_UNESCAPED_UNICODE);
+
+    // Save the updated JSON back to the database
+    $update_stmt = $pdo->prepare("UPDATE bills SET settlement_details = :settlement_details WHERE id = :bill_id");
+    $update_stmt->execute([
+        ':settlement_details' => $new_settlement_details_json,
+        ':bill_id' => $bill_id
+    ]);
+
+    http_response_code(200);
+    echo json_encode(['success' => true, 'message' => 'Settlement updated successfully.']);
+
+} catch (PDOException $e) {
+    error_log("Update settlement DB error: " . $e->getMessage());
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'A server error occurred while updating the settlement.']);
+}
+?>

--- a/backend/test.php
+++ b/backend/test.php
@@ -1,3 +1,0 @@
-<?php
-phpinfo();
-?>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -292,3 +292,104 @@ a:hover {
   font-size: inherit;
   cursor: pointer;
 }
+
+/* Bill Details Viewer */
+.bill-details-viewer {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background-color: var(--background-color);
+}
+
+.navigation-buttons {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+/* Slip Item Styling */
+.slips-list-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.slip-item-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background-color: white;
+}
+
+.slip-panel h4 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: var(--text-color-muted);
+  font-size: 0.9em;
+  text-transform: uppercase;
+}
+
+.slip-panel pre, .slip-panel textarea {
+  background-color: #f8f9fa;
+  padding: 0.8rem;
+  border-radius: 4px;
+  border: 1px solid #e9ecef;
+  min-height: 100px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: monospace;
+}
+
+.slip-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.error-text {
+  color: var(--error-color);
+  font-size: 0.9em;
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  /* Responsive Bills Table */
+  .bills-table thead {
+    display: none;
+  }
+  .bills-table tr {
+    display: block;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    padding: 1rem;
+  }
+  .bills-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--border-color-light);
+    padding: 0.8rem 0;
+    text-align: right;
+  }
+  .bills-table td:last-child {
+    border-bottom: none;
+  }
+  .bills-table td::before {
+    content: attr(data-label);
+    font-weight: bold;
+    text-align: left;
+    margin-right: 1rem;
+    color: var(--text-color);
+  }
+
+  /* Responsive Slip Item Layout */
+  .slip-item-container {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/BillsPage.jsx
+++ b/frontend/src/pages/BillsPage.jsx
@@ -1,153 +1,99 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 
-// 单条结算详情显示（兼容旧账单）
-function SettlementDetails({ details }) {
-  if (!details) return <div className="details-container">没有详细信息。</div>;
+// New component to display and manage a single slip item
+function SlipItem({ slip, index, billId, onBillUpdate }) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [settlementText, setSettlementText] = useState(slip.settlement);
+  const [error, setError] = useState('');
 
-  let parsedDetails;
-  try {
-    parsedDetails = typeof details === 'string' ? JSON.parse(details) : details;
-  } catch (e) {
-    return <div className="details-container">无法解析详细信息。</div>;
-  }
-  // 判断是否是单条（老数据）
-  if (parsedDetails.zodiac_bets || parsedDetails.number_bets) {
-    const { zodiac_bets, number_bets, summary } = parsedDetails;
-    return (
-      <div className="details-container" style={{ padding: '10px' }}>
-        <h4>结算单详情</h4>
-        {zodiac_bets && zodiac_bets.length > 0 && (
-          <div className="details-section">
-            <strong>生肖投注:</strong>
-            <ul>
-              {zodiac_bets.map((bet, index) => (
-                <li key={index}>
-                  `{bet.zodiac}`: {bet.numbers.join(', ')} (<strong>{bet.cost}元</strong>)
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {number_bets && number_bets.numbers && number_bets.numbers.length > 0 && (
-          <div className="details-section">
-            <strong>单独号码投注:</strong>
-            <p>{number_bets.numbers.join(', ')} (<strong>{number_bets.cost}元</strong>)</p>
-          </div>
-        )}
-        {summary && (
-          <div className="details-summary">
-            <strong>总结:</strong>
-            <p>总计: <strong>{summary.total_unique_numbers}</strong> 个号码</p>
-            <p>总金额: <strong>{summary.total_cost}</strong> 元</p>
-          </div>
-        )}
-      </div>
-    );
-  }
-  // 多条结算由 MultiSettlementDetails 渲染
-  return null;
-}
-
-// 多条下注单窗口
-function MultiSettlementDetails({ details, billId }) {
-  const [markedIndexes, setMarkedIndexes] = useState(() => {
-    const key = `bill_${billId}_marked`;
-    const saved = localStorage.getItem(key);
-    return saved ? JSON.parse(saved) : [];
-  });
-
-  let settlements;
-  try {
-    settlements = typeof details === 'string' ? JSON.parse(details) : details;
-  } catch {
-    return <div>无法解析结算详情。</div>;
-  }
-
-  const [currentIdx, setCurrentIdx] = useState(0);
-
-  const handleMark = (index) => {
-    const newMarked = [...markedIndexes, index];
-    setMarkedIndexes(newMarked);
-    localStorage.setItem(`bill_${billId}_marked`, JSON.stringify(newMarked));
+  const handleSave = async () => {
+    setError('');
+    try {
+      const response = await fetch('/?action=update_settlement', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          bill_id: billId,
+          slip_index: index,
+          settlement_text: settlementText,
+        }),
+        credentials: 'include',
+      });
+      const data = await response.json();
+      if (data.success) {
+        setIsEditing(false);
+        // Notify parent component to refetch or update bill data
+        if(onBillUpdate) onBillUpdate();
+      } else {
+        setError(data.error || 'Failed to save settlement.');
+      }
+    } catch (err) {
+      setError('An error occurred while saving.');
+    }
   };
-
-  const handleUnmark = (index) => {
-    const newMarked = markedIndexes.filter(i => i !== index);
-    setMarkedIndexes(newMarked);
-    localStorage.setItem(`bill_${billId}_marked`, JSON.stringify(newMarked));
-  };
-
-  if (!Array.isArray(settlements) || settlements.length === 0) {
-    return <div>没有详细信息。</div>;
-  }
-
-  const current = settlements[currentIdx];
-  const isMarked = markedIndexes.includes(current.index);
-
-  // 统计未被标记
-  const validSettlements = settlements.filter(s => !markedIndexes.includes(s.index));
-  const totalNumbers = validSettlements.reduce((sum, s) => sum + (s.result?.summary?.total_unique_numbers || 0), 0);
-  const totalCost = validSettlements.reduce((sum, s) => sum + (s.result?.summary?.total_cost || 0), 0);
 
   return (
-    <div className="multi-details-container">
-      <div className="multi-details-nav">
-        <button onClick={() => setCurrentIdx(idx => Math.max(idx - 1, 0))} disabled={currentIdx === 0}>上一条</button>
-        <span>第 {currentIdx + 1} / {settlements.length} 条下注单</span>
-        <button onClick={() => setCurrentIdx(idx => Math.min(idx + 1, settlements.length - 1))} disabled={currentIdx === settlements.length - 1}>下一条</button>
+    <div className="slip-item-container">
+      <div className="slip-panel raw-panel">
+        <h4>下注原文</h4>
+        <pre>{slip.raw}</pre>
       </div>
-      <div className="single-bet-section" style={{ margin: '10px 0', padding: '8px', border: '1px solid #eee', borderRadius: '8px' }}>
-        <div>
-          <strong>下注内容：</strong>
-          <pre>{current.raw}</pre>
-        </div>
-        <div>
-          <strong>结算结果：</strong>
-          <SettlementDetails details={current.result} />
-        </div>
-        <div>
-          {isMarked ? (
-            <button onClick={() => handleUnmark(current.index)} style={{ color: 'orange' }}>取消标记</button>
+      <div className="slip-panel settlement-panel">
+        <h4>结算结果</h4>
+        {isEditing ? (
+          <textarea
+            value={settlementText}
+            onChange={(e) => setSettlementText(e.target.value)}
+            rows={5}
+          />
+        ) : (
+          <pre>{settlementText || '(无结算内容)'}</pre>
+        )}
+        <div className="slip-actions">
+          {isEditing ? (
+            <>
+              <button onClick={handleSave}>保存</button>
+              <button onClick={() => setIsEditing(false)} className="secondary">取消</button>
+            </>
           ) : (
-            <button onClick={() => handleMark(current.index)} style={{ color: 'red' }}>标记为错误</button>
+            <button onClick={() => setIsEditing(true)}>修改</button>
           )}
         </div>
-        {isMarked && <span style={{ color: 'red', fontWeight: 'bold' }}>已标记为错误</span>}
-      </div>
-      <div className="multi-details-summary" style={{ marginTop: '16px', paddingTop: '8px', borderTop: '1px solid #ccc' }}>
-        <strong>未标记下注单统计：</strong>
-        <p>总号码数：<strong>{totalNumbers}</strong> 个</p>
-        <p>总金额：<strong>{totalCost}</strong> 元</p>
+        {error && <p className="error-text">{error}</p>}
       </div>
     </div>
   );
 }
 
-function BillDetailsViewer({ bill, onPrev, onNext, isPrevDisabled, isNextDisabled }) {
-  // 判断是否多条结算
-  let isMulti = false;
+function BillDetailsViewer({ bill, onPrev, onNext, isPrevDisabled, isNextDisabled, onBillUpdate }) {
+  let slips = [];
   try {
     const parsed = JSON.parse(bill.settlement_details);
-    isMulti = Array.isArray(parsed);
-  } catch {}
+    if (Array.isArray(parsed)) {
+      slips = parsed;
+    }
+  } catch (e) {
+    slips = []; // If parsing fails, start with an empty list
+  }
+
   return (
     <div className="bill-details-viewer">
       <div className="navigation-buttons">
         <button onClick={onPrev} disabled={isPrevDisabled}>&larr; 上一条</button>
         <button onClick={onNext} disabled={isNextDisabled}>下一条 &rarr;</button>
       </div>
-      <div className="panels-container">
-        <div className="panel">
-          <h3>邮件原文</h3>
-          <pre className="raw-content-panel">{bill.raw_content}</pre>
-        </div>
-        <div className="panel">
-          <h3>结算内容</h3>
-          {isMulti
-            ? <MultiSettlementDetails details={bill.settlement_details} billId={bill.id} />
-            : <SettlementDetails details={bill.settlement_details} />}
-        </div>
+      <h3>账单详情 (总计 {slips.length} 条下注)</h3>
+      <div className="slips-list-container">
+        {slips.map((slip, index) => (
+          <SlipItem
+            key={index}
+            slip={slip}
+            index={index}
+            billId={bill.id}
+            onBillUpdate={onBillUpdate}
+          />
+        ))}
       </div>
     </div>
   );
@@ -165,7 +111,7 @@ function BillsPage() {
     setIsLoading(true);
     setError('');
     try {
-      const response = await fetch('/get_bills', {
+      const response = await fetch('/?action=get_bills', {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include'
@@ -212,7 +158,7 @@ function BillsPage() {
       return;
     }
     try {
-      const response = await fetch('/delete_bill', {
+      const response = await fetch('/?action=delete_bill', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ bill_id: billId }),
@@ -276,11 +222,11 @@ function BillsPage() {
                 onClick={() => handleSelectBill(index)}
                 className={selectedBillIndex === index ? 'selected-row' : ''}
               >
-                <td>{bill.id}</td>
-                <td>{new Date(bill.created_at).toLocaleString()}</td>
-                <td>{bill.total_cost ? `${bill.total_cost} 元` : 'N/A'}</td>
-                <td>{renderStatus(bill.status)}</td>
-                <td>
+                <td data-label="账单ID">{bill.id}</td>
+                <td data-label="创建时间">{new Date(bill.created_at).toLocaleString()}</td>
+                <td data-label="总金额">{bill.total_cost ? `${bill.total_cost} 元` : 'N/A'}</td>
+                <td data-label="状态">{renderStatus(bill.status)}</td>
+                <td data-label="操作">
                   <button onClick={(e) => { e.stopPropagation(); handleDeleteBill(bill.id); }} className="delete-button">
                     删除
                   </button>
@@ -297,6 +243,7 @@ function BillsPage() {
           onNext={handleNextBill}
           isPrevDisabled={selectedBillIndex === 0}
           isNextDisabled={selectedBillIndex === bills.length - 1}
+          onBillUpdate={fetchBills}
         />
       )}
     </div>


### PR DESCRIPTION
This commit delivers the complete and stable version of the manual settlement feature, built from a clean baseline to resolve all previous issues.

- Implemented a simple, temporary "split by blank lines" email parsing logic in `email_upload.php` as a stable placeholder.
- Re-created the `update_settlement.php` endpoint to securely save manually edited settlement text.
- Re-implemented the `BillsPage.jsx` frontend to feature a responsive UI where each slip can be individually viewed and its settlement text edited and saved.
- Removed all obsolete code and features, such as the `BetCalculator.php` and the 'mark as incorrect' button.
- Ensured all backend API calls from the frontend use the correct `/?action=` URL format.
- Cleaned up diagnostic files before submission.