### PR TITLE
feat: Redesign settlement details modal to show all slips

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -186,20 +186,37 @@ button:active {
   background: #f3f6fd;
   color: #007bff;
   font-weight: 600;
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 .multi-slips-table .slip-raw .slip-pre {
   background: #f7fafc;
   margin: 0;
   padding: 6px;
   border-radius: 6px;
-  font-size: 0.98em;
+  font-size: 0.9em;
   font-family: 'Fira Mono', 'Consolas', monospace;
   white-space: pre-wrap;
   word-break: break-all;
-  max-width: 100%;
+  max-height: 150px;
+  overflow-y: auto;
 }
 .multi-slips-table .slip-result {
   word-break: break-word;
+}
+.multi-slips-table .slip-time {
+  width: 90px;
+  text-align: center;
+}
+.multi-slips-table .slip-cost {
+  width: 100px;
+  text-align: right;
+  font-size: 1.1em;
+}
+.multi-slips-table .summary-total-cost {
+  text-align: right;
+  font-size: 1.1em;
 }
 
 /* 单条结算详情表格 */
@@ -378,6 +395,9 @@ button:active {
   overflow-y: auto;
   overflow-x: hidden;
   box-sizing: border-box;
+}
+.modal-content.wide-modal {
+  max-width: 90vw;
 }
 .no-slips-message {
   padding: 20px;


### PR DESCRIPTION
This commit completely redesigns the settlement details modal to provide a more comprehensive and user-friendly view, addressing the request to see all individual bet results at once.

Key changes:

1.  **Redesigned `SettlementModal` (`BillsPage.jsx`):**
    -   The modal no longer displays one slip at a time with "next/previous" buttons.
    -   It now features a comprehensive table that lists every individual betting slip from the bill.
    -   Each row in the table displays the slip's original text, a detailed breakdown of the parsed bets, and the calculated cost for that specific slip.

2.  **Improved Summary Display:**
    -   A summary footer (`tfoot`) has been added to the table to show the total cost for the entire bill.
    -   A summary section below the table displays the total number of bets.

3.  **Enhanced Styling (`App.css`):**
    -   Added a `wide-modal` class to make the settlement details modal wider to accommodate the new table.
    -   Added specific styles for the table's columns, raw text container, and summary row to ensure readability and responsiveness.
    -   Made the table headers sticky so they remain visible when scrolling through a long list of slips.