### PR TITLE
feat: Redesign settlement details with a card-based layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -159,64 +159,66 @@ button:active {
 /* ==============================
    结算内容卡片与表格
    ============================== */
-.multi-details-container {
-  width: 100%;
-  min-width: 0;
-  box-sizing: border-box;
+.slips-card-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0.5rem;
 }
-.multi-slips-table {
-  width: 100%;
-  border-collapse: collapse;
+.bet-slip-card {
+  display: flex;
   background: #fff;
-  margin-top: 1vw;
+  border: 1px solid var(--border);
   border-radius: 12px;
   box-shadow: var(--shadow);
-  font-size: 0.98em;
-  table-layout: fixed;
+  overflow: hidden;
 }
-.multi-slips-table th,
-.multi-slips-table td {
-  border-bottom: 1px solid #e1e5ef;
-  padding: 0.7em 0.6em;
-  text-align: left;
-  vertical-align: top;
-  word-break: break-word;
+.bet-slip-card > div {
+  padding: 1rem;
 }
-.multi-slips-table th {
-  background: #f3f6fd;
-  color: #007bff;
+.slip-raw {
+  flex: 1.5;
+  background: #fcfdff;
+  border-right: 1px solid var(--border);
+}
+.slip-card-header {
   font-weight: 600;
-  position: sticky;
-  top: 0;
-  z-index: 1;
+  margin-bottom: 0.5rem;
 }
-.multi-slips-table .slip-raw .slip-pre {
+.slip-pre {
   background: #f7fafc;
   margin: 0;
-  padding: 6px;
+  padding: 0.5rem;
   border-radius: 6px;
   font-size: 0.9em;
   font-family: 'Fira Mono', 'Consolas', monospace;
   white-space: pre-wrap;
   word-break: break-all;
-  max-height: 150px;
+  max-height: 200px;
   overflow-y: auto;
+  border: 1px solid #e9eef5;
 }
-.multi-slips-table .slip-result {
-  word-break: break-word;
+.slip-result {
+  flex: 3;
 }
-.multi-slips-table .slip-time {
-  width: 90px;
+.slip-cost {
+  flex: 1;
+  background: #fcfdff;
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
+  gap: 0.25rem;
 }
-.multi-slips-table .slip-cost {
-  width: 100px;
-  text-align: right;
-  font-size: 1.1em;
+.slip-cost span {
+  font-size: 0.9em;
+  color: var(--text-muted);
 }
-.multi-slips-table .summary-total-cost {
-  text-align: right;
-  font-size: 1.1em;
+.slip-cost strong {
+  font-size: 1.5em;
+  color: var(--primary-color);
 }
 
 /* 单条结算详情表格 */
@@ -294,15 +296,26 @@ button:active {
 }
 
 /* 总计高亮 */
-.summary-row { font-size: 1.07em; background: #f0f8ff; }
 .multi-details-summary {
-  margin-top: 2vw;
-  padding: 1vw 1vw 1vw 2vw;
-  border-top: 2px solid #4F8CFF;
-  background: #eaf3ff;
+  margin-top: 1rem;
+  padding: 1rem;
+  border-top: 2px solid var(--primary-color);
+  background: #f0f8ff;
   border-radius: 8px;
-  font-size: 1.08em;
-  word-break: break-word;
+  font-size: 1.1em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 600;
+}
+.multi-details-summary span {
+  color: var(--primary-hover);
+  font-weight: bold;
+}
+.summary-divider {
+  color: var(--border);
+  font-weight: normal;
 }
 
 /* ==============================
@@ -590,6 +603,23 @@ p.success {
   .panel { padding: 1vw; }
   .modal-content { padding: 1.2vw; }
 }
+
+@media (max-width: 768px) {
+  .bet-slip-card {
+    flex-direction: column;
+  }
+  .slip-raw, .slip-cost {
+    border-right: none;
+    border-left: none;
+  }
+  .slip-raw, .slip-result {
+    border-bottom: 1px solid var(--border);
+  }
+  .slip-cost {
+    border-bottom: none;
+  }
+}
+
 @media (max-width: 600px) {
   #root { padding: 1vw 0.5vw; }
   main { padding: 0.5vw; }

--- a/frontend/src/pages/BillsPage.jsx
+++ b/frontend/src/pages/BillsPage.jsx
@@ -117,7 +117,7 @@ function RawModal({ open, rawContent, onClose }) {
   );
 }
 
-// 结算详情弹窗（展示所有分段的表格）
+// 结算详情弹窗（卡片式布局）
 function SettlementModal({ open, bill, onClose }) {
   if (!open || !bill) return null;
 
@@ -141,45 +141,30 @@ function SettlementModal({ open, bill, onClose }) {
         {slips.length === 0 ? (
           <div className="no-slips-message">没有解析到有效的分段下注单。</div>
         ) : (
-          <div className="multi-details-container">
-            <table className="multi-slips-table">
-              <thead>
-                <tr>
-                  <th>时间</th>
-                  <th>下注单原文</th>
-                  <th>解析结果</th>
-                  <th>金额</th>
-                </tr>
-              </thead>
-              <tbody>
-                {slips.map((slip, index) => (
-                  <tr key={index}>
-                    <td className="slip-time">
-                      {slip.time ? <span className="time-tag">{slip.time}</span> : `第 ${slip.index} 段`}
-                    </td>
-                    <td className="slip-raw">
-                      <pre className="slip-pre">{slip.raw}</pre>
-                    </td>
-                    <td className="slip-result">
-                      <SettlementDetails details={slip.result} />
-                    </td>
-                    <td className="slip-cost">
-                      <strong>{slip.result?.summary?.total_cost || 0} 元</strong>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-              <tfoot>
-                <tr className="summary-row">
-                  <td colSpan="3">总计</td>
-                  <td className="summary-total-cost">
-                    <strong>{summary.total_cost || 0} 元</strong>
-                  </td>
-                </tr>
-              </tfoot>
-            </table>
+          <div className="slips-card-container">
+            {slips.map((slip, index) => (
+              <div key={index} className="bet-slip-card">
+                <div className="slip-raw">
+                  <div className="slip-card-header">
+                    {slip.time ? <span className="time-tag">{slip.time}</span> : `第 ${slip.index} 段`}
+                  </div>
+                  <pre className="slip-pre">{slip.raw}</pre>
+                </div>
+                <div className="slip-result">
+                  <SettlementDetails details={slip.result} />
+                </div>
+                <div className="slip-cost">
+                  <span>小计</span>
+                  <strong>{slip.result?.summary?.total_cost || 0} 元</strong>
+                </div>
+              </div>
+            ))}
             <div className="multi-details-summary">
-              <strong>总号码数:</strong> {summary.total_number_count || 0} 个
+              <strong>总计:</strong>
+              <span>{summary.total_cost || 0} 元</span>
+              <span className="summary-divider">|</span>
+              <strong>总号码数:</strong>
+              <span>{summary.total_number_count || 0} 个</span>
             </div>
           </div>
         )}


### PR DESCRIPTION
This commit introduces a modern, card-based design for the settlement details modal, replacing the previous table-based layout to improve readability and user experience, especially on mobile devices.

Key changes:

1.  **Card-Based Layout (`BillsPage.jsx`):**
    -   The `SettlementModal` has been refactored to use a `div`-based card layout instead of a `<table>`.
    -   Each individual betting slip is now rendered in its own "card" (`.bet-slip-card`), which contains the slip's raw text, its parsed result, and its subtotal cost.

2.  **New CSS Styles (`App.css`):**
    -   Added styles for the `.bet-slip-card` and its child elements to create a clean, modern, and responsive design.
    -   The old, unused styles for the `multi-slips-table` have been removed.

3.  **Responsive Design:**
    -   A new media query has been added to stack the card sections vertically on screens narrower than 768px, ensuring the layout is fully responsive.