### PR TITLE
feat: Add inline editing to settlement detail cards

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -220,6 +220,26 @@ button:active {
   font-size: 1.5em;
   color: var(--primary-color);
 }
+.slip-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+.action-button {
+  padding: 0.4em 0.8em;
+  font-size: 0.9em;
+  border-radius: 6px;
+}
+.action-button.save {
+  background-color: var(--success);
+}
+.action-button.cancel {
+  background-color: var(--text-muted);
+}
+.bet-slip-card.editing {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 12px rgba(79, 140, 255, 0.2);
+}
 
 /* 单条结算详情表格 */
 .settlement-table {


### PR DESCRIPTION
This commit introduces the ability to edit settlement remarks directly within the new card-based settlement details modal, making the system more interactive and user-friendly.

Key changes:

1.  **State Management (`BillsPage.jsx`):**
    -   Re-introduced state management to the `SettlementModal` to handle the editing lifecycle of each individual bet slip card. This includes tracking the active editing card, the note's content, and the saving status.

2.  **Inline Editing UI:**
    -   An "Edit" button has been added to each bet slip card, which, when clicked, reveals a `textarea` and "Save"/"Cancel" buttons for that specific card.
    -   The UI now provides clear visual feedback, highlighting the card that is currently being edited.

3.  **Updated Save Logic:**
    -   The `handleSaveEdit` function has been updated to correctly save the note for the specific slip being edited.
    -   After a successful save, the main bills list is refreshed to ensure the data is up-to-date.

4.  **New CSS Styles (`App.css`):**
    -   Added styles for the new "Edit," "Save," and "Cancel" buttons to make them visually distinct.
    -   Added a style for the `.editing` class to provide a visual highlight for the active card.