### PR TITLE
feat: Implement confidence scoring system for parsing

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -180,28 +180,43 @@ if (empty($calculation_content)) {
 }
 
 // 多段结算
-$multi_slip = BetCalculator::calculateMulti($calculation_content);
+$multi_slip_result = BetCalculator::calculateMulti($calculation_content);
+
+// Default values
 $status = 'unrecognized';
 $settlement_details = null;
 $total_cost = null;
+$confidence = 0.0;
+$unparsed_text = $calculation_content; // By default, everything is unparsed if calculation fails
 
 // Only set status to 'processed' if the calculator found valid bet slips.
-if ($multi_slip !== null && !empty($multi_slip['slips'])) {
+if ($multi_slip_result !== null && !empty($multi_slip_result['slips'])) {
     $status = 'processed';
-    $settlement_details = json_encode($multi_slip, JSON_UNESCAPED_UNICODE);
-    $total_cost = $multi_slip['summary']['total_cost'] ?? 0;
+    // We only need to store the slips and summary in the settlement_details column
+    $settlement_data_to_store = [
+        'slips' => $multi_slip_result['slips'],
+        'summary' => $multi_slip_result['summary']
+    ];
+    $settlement_details = json_encode($settlement_data_to_store, JSON_UNESCAPED_UNICODE);
+
+    $total_cost = $multi_slip_result['summary']['total_cost'] ?? 0;
+    $confidence = $multi_slip_result['confidence'] ?? 0.0;
+    $unparsed_text = $multi_slip_result['unparsed_text'] ?? '';
 }
 
 try {
-    $sql = "INSERT INTO bills (user_id, raw_content, settlement_details, total_cost, status)
-            VALUES (:user_id, :raw_content, :settlement_details, :total_cost, :status)";
+    // Note the added columns: confidence, unparsed_text
+    $sql = "INSERT INTO bills (user_id, raw_content, settlement_details, total_cost, status, confidence, unparsed_text)
+            VALUES (:user_id, :raw_content, :settlement_details, :total_cost, :status, :confidence, :unparsed_text)";
     $stmt = $pdo->prepare($sql);
     $stmt->execute([
         ':user_id' => $user_id,
         ':raw_content' => $text_body . ($html_body ? "\n\n---HTML正文---\n" . $html_body : ''),
         ':settlement_details' => $settlement_details,
         ':total_cost' => $total_cost,
-        ':status' => $status
+        ':status' => $status,
+        ':confidence' => $confidence,
+        ':unparsed_text' => $unparsed_text
     ]);
     http_response_code(201);
     echo json_encode([

--- a/backend/actions/get_bills.php
+++ b/backend/actions/get_bills.php
@@ -10,7 +10,8 @@ $user_id = $_SESSION['user_id'];
 
 try {
     // The $pdo variable is inherited from index.php
-    $sql = "SELECT id, raw_content, total_cost, status, created_at, settlement_details FROM bills WHERE user_id = :user_id ORDER BY created_at DESC";
+    // Added `confidence` and `unparsed_text` to the selection
+    $sql = "SELECT id, raw_content, total_cost, status, created_at, settlement_details, confidence, unparsed_text FROM bills WHERE user_id = :user_id ORDER BY created_at DESC";
     $stmt = $pdo->prepare($sql);
     $stmt->execute([':user_id' => $user_id]);
 

--- a/backend/data_table_schema.sql
+++ b/backend/data_table_schema.sql
@@ -35,6 +35,8 @@ CREATE TABLE IF NOT EXISTS `bills` (
   `settlement_details` LONGTEXT NULL,
   `total_cost` DECIMAL(10, 2) NULL,
   `status` VARCHAR(50) NOT NULL DEFAULT 'unrecognized',
+  `confidence` DECIMAL(5, 4) NULL COMMENT 'Confidence score of the parsing, from 0.0 to 1.0',
+  `unparsed_text` TEXT NULL COMMENT 'Any text that was not successfully parsed',
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/frontend/src/components/modals/RawModal.jsx
+++ b/frontend/src/components/modals/RawModal.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+/**
+ * A modal dialog to display raw text content.
+ * Closes when the overlay or the close button is clicked.
+ * @param {object} props
+ * @param {boolean} props.open - Whether the modal is open.
+ * @param {string} props.rawContent - The text content to display.
+ * @param {function} props.onClose - The function to call when the modal should close.
+ */
+function RawModal({ open, rawContent, onClose }) {
+  if (!open) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal-content"
+        style={{
+          maxWidth: 600,
+          width: '98vw',
+          minWidth: 260,
+          maxHeight: '98vh',
+          overflowY: 'auto',
+          boxSizing: 'border-box'
+        }}
+        onClick={e => e.stopPropagation()}
+      >
+        <button className="modal-close-button" onClick={onClose}>&times;</button>
+        <h2>邮件原文</h2>
+        <div className="panel" style={{ background: '#f7f8fa', padding: '1em' }}>
+          <pre className="raw-content-panel" style={{ fontSize: '1em', maxHeight: 400, overflow: 'auto' }}>
+            {rawContent}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default RawModal;

--- a/frontend/src/components/modals/SettlementModal.jsx
+++ b/frontend/src/components/modals/SettlementModal.jsx
@@ -1,0 +1,220 @@
+import React, { useState, useEffect } from 'react';
+
+// This is a sub-component used only within the SettlementModal.
+function SettlementDetails({ details }) {
+  if (!details) return <div className="details-container">没有详细信息。</div>;
+
+  const { zodiac_bets, number_bets, summary, settlement } = details || {};
+  const safe_zodiac_bets = Array.isArray(zodiac_bets) ? zodiac_bets : [];
+  const safe_number_bets = Array.isArray(number_bets) ? number_bets : [];
+
+  if (safe_zodiac_bets.length === 0 && safe_number_bets.length === 0) {
+    return <div className="details-container">没有解析到投注。</div>;
+  }
+
+  return (
+    <div className="details-container">
+      <table className="settlement-table">
+        <thead>
+          <tr>
+            <th>类型</th>
+            <th>内容</th>
+            <th>金额</th>
+          </tr>
+        </thead>
+        <tbody>
+          {safe_zodiac_bets.map((bet, idx) => (
+            <tr key={`zodiac-${idx}`}>
+              <td className="type-zodiac">生肖投注</td>
+              <td>
+                <span className="zodiac-tag">{bet.zodiac}</span>
+                <span>: {bet.numbers.join(', ')}</span>
+              </td>
+              <td className="amount">{bet.cost} 元</td>
+            </tr>
+          ))}
+          {safe_number_bets.map((bet, idx) => (
+            <tr key={`number-${idx}`}>
+              <td className="type-number">号码投注</td>
+              <td>{bet.numbers.join(', ')}</td>
+              <td className="amount">{bet.cost} 元</td>
+            </tr>
+          ))}
+        </tbody>
+        {summary && (
+          <tfoot>
+            <tr>
+              <td colSpan="2" className="summary-label">号码总数</td>
+              <td className="summary-value">{summary.number_count ?? 0} 个</td>
+            </tr>
+            <tr>
+              <td colSpan="2" className="summary-label">总金额</td>
+              <td className="summary-value">{summary.total_cost ?? 0} 元</td>
+            </tr>
+          </tfoot>
+        )}
+      </table>
+      <div className="settlement-notes-section">
+        <strong>结算备注/说明：</strong>
+        <div className="readonly-notes">
+          {settlement || <span className="no-notes">暂无备注</span>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+function SettlementModal({ open, bill, onClose, onSaveSuccess }) {
+  const [editingSlipIndex, setEditingSlipIndex] = useState(null);
+  const [editedText, setEditedText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveResult, setSaveResult] = useState({ index: null, message: '' });
+
+  useEffect(() => {
+    if (!open) {
+      setEditingSlipIndex(null);
+      setEditedText('');
+      setSaving(false);
+      setSaveResult({ index: null, message: '' });
+    }
+  }, [open]);
+
+  if (!open || !bill) return null;
+
+  let parsedDetails;
+  try {
+    parsedDetails = typeof bill.settlement_details === 'string'
+      ? JSON.parse(bill.settlement_details)
+      : bill.settlement_details;
+  } catch {
+    parsedDetails = { slips: [], summary: {} };
+  }
+
+  const slips = parsedDetails?.slips || [];
+  const summary = parsedDetails?.summary || {};
+
+  const handleEditClick = (index) => {
+    // Note: The structure from the backend is now nested under `settlement_details`
+    setEditingSlipIndex(index);
+    setEditedText(slips[index]?.settlement_details?.settlement || '');
+    setSaveResult({ index: null, message: '' });
+  };
+
+  const handleCancelClick = () => {
+    setEditingSlipIndex(null);
+    setEditedText('');
+  };
+
+  const handleSaveEdit = async () => {
+    setSaving(true);
+    setSaveResult({ index: editingSlipIndex, message: '' });
+    try {
+      const response = await fetch('/update_settlement', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          bill_id: bill.id,
+          slip_index: editingSlipIndex,
+          settlement_text: editedText,
+        }),
+        credentials: 'include'
+      });
+      const data = await response.json();
+      if (data.success) {
+        setSaveResult({ index: editingSlipIndex, message: '保存成功！' });
+        onSaveSuccess();
+        setTimeout(() => setEditingSlipIndex(null), 1500);
+      } else {
+        setSaveResult({ index: editingSlipIndex, message: `保存失败: ${data.error || '未知错误'}` });
+      }
+    } catch (err) {
+      setSaveResult({ index: editingSlipIndex, message: '保存失败: 网络错误' });
+    }
+    setSaving(false);
+  };
+
+  const confidence = bill.confidence ? parseFloat(bill.confidence) : 1.0;
+  const showWarning = confidence < 0.95 && bill.unparsed_text;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content wide-modal" onClick={e => e.stopPropagation()}>
+        <button className="modal-close-button" onClick={onClose}>&times;</button>
+        <h2>结算详情 (账单 #{bill.id})</h2>
+        {showWarning && (
+          <div className="confidence-warning">
+            <strong>⚠️ 系统无法完全识别此邮件，请您仔细核对以下未识别内容：</strong>
+            <pre className="unparsed-text-panel">{bill.unparsed_text}</pre>
+          </div>
+        )}
+        {slips.length === 0 ? (
+          <div className="no-slips-message">没有解析到有效的分段下注单。</div>
+        ) : (
+          <div className="slips-card-container">
+            {slips.map((slip, index) => (
+              <div key={index} className={`bet-slip-card ${editingSlipIndex === index ? 'editing' : ''}`}>
+                <div className="slip-raw">
+                  <div className="slip-card-header">
+                    {slip.region && <span className="region-tag">{slip.region}</span>}
+                    {slip.time ? <span className="time-tag">{slip.time}</span> : `第 ${slip.index} 段`}
+                  </div>
+                  <pre className="slip-pre">{slip.raw}</pre>
+                </div>
+                <div className="slip-result">
+                  <SettlementDetails details={slip.settlement_details} />
+                  {editingSlipIndex === index && (
+                    <div className="editable-notes">
+                      <textarea
+                        value={editedText}
+                        onChange={(e) => setEditedText(e.target.value)}
+                        rows={3}
+                        className="notes-textarea"
+                        placeholder="可编辑结算说明..."
+                        disabled={saving}
+                      />
+                      {saveResult.index === index && saveResult.message && (
+                        <div className={`save-result ${saveResult.message.startsWith('保存成功') ? 'success' : 'error'}`}>
+                          {saveResult.message}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+                <div className="slip-cost">
+                  <span>小计</span>
+                  <strong>{slip.settlement_details?.summary?.total_cost || 0} 元</strong>
+                  <div className="slip-actions">
+                    {editingSlipIndex === index ? (
+                      <>
+                        <button onClick={handleSaveEdit} disabled={saving} className="action-button save">
+                          {saving ? '保存中...' : '保存'}
+                        </button>
+                        <button onClick={handleCancelClick} disabled={saving} className="action-button cancel">
+                          取消
+                        </button>
+                      </>
+                    ) : (
+                      <button onClick={() => handleEditClick(index)} className="action-button edit">
+                        编辑备注
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+            <div className="multi-details-summary">
+              <strong>总计:</strong>
+              <span>{summary.total_cost || 0} 元</span>
+              <span className="summary-divider">|</span>
+              <strong>总号码数:</strong>
+              <span>{summary.total_number_count || 0} 个</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default SettlementModal;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -59,3 +59,48 @@ a:hover {
   color: var(--primary-color-hover);
   text-decoration: underline;
 }
+
+/* Status and Confidence Styles */
+.status-processed { color: var(--success-color); font-weight: bold; }
+.status-unrecognized { color: var(--error-color); font-weight: bold; }
+.status-default { color: var(--text-muted-light); }
+
+.confidence-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.confidence-indicator {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.confidence-indicator.high { background-color: #2ecc71; } /* Green */
+.confidence-indicator.medium { background-color: #f1c40f; } /* Yellow */
+.confidence-indicator.low { background-color: #e74c3c; } /* Red */
+
+.confidence-warning {
+  background-color: #fffbe6;
+  border: 1px solid #ffe58f;
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+}
+.confidence-warning strong {
+  color: #d46b08;
+}
+
+.unparsed-text-panel {
+  background: #fff;
+  border: 1px dashed #d9d9d9;
+  padding: 8px;
+  margin-top: 8px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  font-size: 0.9em;
+  max-height: 150px;
+  overflow-y: auto;
+}

--- a/frontend/src/pages/BillsPage.jsx
+++ b/frontend/src/pages/BillsPage.jsx
@@ -1,251 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
-
-// 单条结算详情（仅用于显示）
-function SettlementDetails({ details }) {
-  if (!details) return <div className="details-container">没有详细信息。</div>;
-
-  let parsedDetails;
-  try {
-    parsedDetails = typeof details === 'string' ? JSON.parse(details) : details;
-  } catch (e) {
-    return <div className="details-container">无法解析详细信息。</div>;
-  }
-
-  const { zodiac_bets, number_bets, summary, settlement } = parsedDetails || {};
-
-  // This component should be robust enough to not crash the page.
-  const safe_zodiac_bets = Array.isArray(zodiac_bets) ? zodiac_bets : [];
-  const safe_number_bets = Array.isArray(number_bets) ? number_bets : [];
-
-  if (safe_zodiac_bets.length === 0 && safe_number_bets.length === 0) {
-    return <div className="details-container">没有解析到投注。</div>;
-  }
-
-  return (
-    <div className="details-container">
-      <table className="settlement-table">
-        <thead>
-          <tr>
-            <th>类型</th>
-            <th>内容</th>
-            <th>金额</th>
-          </tr>
-        </thead>
-        <tbody>
-          {safe_zodiac_bets.map((bet, idx) => (
-            <tr key={`zodiac-${idx}`}>
-              <td className="type-zodiac">生肖投注</td>
-              <td>
-                <span className="zodiac-tag">{bet.zodiac}</span>
-                <span>: {bet.numbers.join(', ')}</span>
-              </td>
-              <td className="amount">{bet.cost} 元</td>
-            </tr>
-          ))}
-          {safe_number_bets.map((bet, idx) => (
-            <tr key={`number-${idx}`}>
-              <td className="type-number">号码投注</td>
-              <td>{bet.numbers.join(', ')}</td>
-              <td className="amount">{bet.cost} 元</td>
-            </tr>
-          ))}
-        </tbody>
-        {summary && (
-          <tfoot>
-            <tr>
-              <td colSpan="2" className="summary-label">号码总数</td>
-              <td className="summary-value">{summary.number_count ?? 0} 个</td>
-            </tr>
-            <tr>
-              <td colSpan="2" className="summary-label">总金额</td>
-              <td className="summary-value">{summary.total_cost ?? 0} 元</td>
-            </tr>
-          </tfoot>
-        )}
-      </table>
-      <div className="settlement-notes-section">
-        <strong>结算备注/说明：</strong>
-        <div className="readonly-notes">
-          {settlement || <span className="no-notes">暂无备注</span>}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// 原文弹窗
-function RawModal({ open, rawContent, onClose }) {
-  if (!open) return null;
-  return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div
-        className="modal-content"
-        style={{
-          maxWidth: 600,
-          width: '98vw',
-          minWidth: 260,
-          maxHeight: '98vh',
-          overflowY: 'auto',
-          boxSizing: 'border-box'
-        }}
-        onClick={e => e.stopPropagation()}
-      >
-        <button className="modal-close-button" onClick={onClose}>&times;</button>
-        <h2>邮件原文</h2>
-        <div className="panel" style={{ background: '#f7f8fa', padding: '1em' }}>
-          <pre className="raw-content-panel" style={{ fontSize: '1em', maxHeight: 400, overflow: 'auto' }}>
-            {rawContent}
-          </pre>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// 结算详情弹窗（卡片式布局）
-function SettlementModal({ open, bill, onClose, onSaveSuccess }) {
-  const [editingSlipIndex, setEditingSlipIndex] = useState(null);
-  const [editedText, setEditedText] = useState('');
-  const [saving, setSaving] = useState(false);
-  const [saveResult, setSaveResult] = useState({ index: null, message: '' });
-
-  useEffect(() => {
-    if (!open) {
-      setEditingSlipIndex(null);
-      setEditedText('');
-      setSaving(false);
-      setSaveResult({ index: null, message: '' });
-    }
-  }, [open]);
-
-  if (!open || !bill) return null;
-
-  let parsedDetails;
-  try {
-    parsedDetails = typeof bill.settlement_details === 'string'
-      ? JSON.parse(bill.settlement_details)
-      : bill.settlement_details;
-  } catch {
-    parsedDetails = { slips: [], summary: {} };
-  }
-
-  const slips = parsedDetails?.slips || [];
-  const summary = parsedDetails?.summary || {};
-
-  const handleEditClick = (index) => {
-    setEditingSlipIndex(index);
-    setEditedText(slips[index]?.result?.settlement || '');
-    setSaveResult({ index: null, message: '' });
-  };
-
-  const handleCancelClick = () => {
-    setEditingSlipIndex(null);
-    setEditedText('');
-  };
-
-  const handleSaveEdit = async () => {
-    setSaving(true);
-    setSaveResult({ index: editingSlipIndex, message: '' });
-    try {
-      const response = await fetch('/update_settlement', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          bill_id: bill.id,
-          slip_index: editingSlipIndex,
-          settlement_text: editedText,
-        }),
-        credentials: 'include'
-      });
-      const data = await response.json();
-      if (data.success) {
-        setSaveResult({ index: editingSlipIndex, message: '保存成功！' });
-        onSaveSuccess(); // Callback to refresh the bills list
-        setTimeout(() => {
-          setEditingSlipIndex(null);
-        }, 1500);
-      } else {
-        setSaveResult({ index: editingSlipIndex, message: `保存失败: ${data.error || '未知错误'}` });
-      }
-    } catch (err) {
-      setSaveResult({ index: editingSlipIndex, message: '保存失败: 网络错误' });
-    }
-    setSaving(false);
-  };
-
-  return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content wide-modal" onClick={e => e.stopPropagation()}>
-        <button className="modal-close-button" onClick={onClose}>&times;</button>
-        <h2>结算详情 (账单 #{bill.id})</h2>
-        {slips.length === 0 ? (
-          <div className="no-slips-message">没有解析到有效的分段下注单。</div>
-        ) : (
-          <div className="slips-card-container">
-            {slips.map((slip, index) => (
-              <div key={index} className={`bet-slip-card ${editingSlipIndex === index ? 'editing' : ''}`}>
-                <div className="slip-raw">
-                  <div className="slip-card-header">
-                    {slip.time ? <span className="time-tag">{slip.time}</span> : `第 ${slip.index} 段`}
-                  </div>
-                  <pre className="slip-pre">{slip.raw}</pre>
-                </div>
-                <div className="slip-result">
-                  <SettlementDetails details={slip.result} />
-                  {editingSlipIndex === index && (
-                    <div className="editable-notes">
-                      <textarea
-                        value={editedText}
-                        onChange={(e) => setEditedText(e.target.value)}
-                        rows={3}
-                        className="notes-textarea"
-                        placeholder="可编辑结算说明..."
-                        disabled={saving}
-                      />
-                      {saveResult.index === index && saveResult.message && (
-                        <div className={`save-result ${saveResult.message.startsWith('保存成功') ? 'success' : 'error'}`}>
-                          {saveResult.message}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-                <div className="slip-cost">
-                  <span>小计</span>
-                  <strong>{slip.result?.summary?.total_cost || 0} 元</strong>
-                  <div className="slip-actions">
-                    {editingSlipIndex === index ? (
-                      <>
-                        <button onClick={handleSaveEdit} disabled={saving} className="action-button save">
-                          {saving ? '保存中...' : '保存'}
-                        </button>
-                        <button onClick={handleCancelClick} disabled={saving} className="action-button cancel">
-                          取消
-                        </button>
-                      </>
-                    ) : (
-                      <button onClick={() => handleEditClick(index)} className="action-button edit">
-                        编辑备注
-                      </button>
-                    )}
-                  </div>
-                </div>
-              </div>
-            ))}
-            <div className="multi-details-summary">
-              <strong>总计:</strong>
-              <span>{summary.total_cost || 0} 元</span>
-              <span className="summary-divider">|</span>
-              <strong>总号码数:</strong>
-              <span>{summary.total_number_count || 0} 个</span>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
+import RawModal from '../components/modals/RawModal';
+import SettlementModal from '../components/modals/SettlementModal';
 
 function BillsPage() {
   const [bills, setBills] = useState([]);
@@ -313,22 +69,33 @@ function BillsPage() {
 
   const renderStatus = (status) => {
     switch (status) {
-      case 'processed':
-        return <span className="status-processed">已处理</span>;
-      case 'unrecognized':
-        return <span className="status-unrecognized">无法识别</span>;
-      default:
-        return <span className="status-default">{status}</span>;
+      case 'processed': return <span className="status-processed">已处理</span>;
+      case 'unrecognized': return <span className="status-unrecognized">无法识别</span>;
+      default: return <span className="status-default">{status}</span>;
     }
   };
 
-  if (isLoading) {
-    return <div>正在加载您的账单...</div>;
-  }
+  const renderConfidence = (confidence) => {
+    if (confidence === null || confidence === undefined) {
+      return <span className="confidence-na">N/A</span>;
+    }
+    const percentage = Math.round(parseFloat(confidence) * 100);
+    let colorClass = 'low';
+    if (percentage >= 95) {
+      colorClass = 'high';
+    } else if (percentage >= 80) {
+      colorClass = 'medium';
+    }
+    return (
+      <div className="confidence-cell" title={`解析置信度: ${percentage}%`}>
+        <span className={`confidence-indicator ${colorClass}`}></span>
+        {`${percentage}%`}
+      </div>
+    );
+  };
 
-  if (error) {
-    return <div className="error">{error}</div>;
-  }
+  if (isLoading) return <div>正在加载您的账单...</div>;
+  if (error) return <div className="error">{error}</div>;
 
   const selectedBill = selectedBillIndex !== null ? bills[selectedBillIndex] : null;
 
@@ -345,30 +112,22 @@ function BillsPage() {
               <th>创建时间</th>
               <th>总金额</th>
               <th>状态</th>
+              <th>置信度</th>
               <th>操作</th>
             </tr>
           </thead>
           <tbody>
             {bills.map((bill, index) => (
-              <tr
-                key={bill.id}
-                className={selectedBillIndex === index ? 'selected-row' : ''}
-              >
+              <tr key={bill.id} className={selectedBillIndex === index ? 'selected-row' : ''}>
                 <td>{bill.id}</td>
                 <td>{new Date(bill.created_at).toLocaleString()}</td>
                 <td>{bill.total_cost ? `${bill.total_cost} 元` : 'N/A'}</td>
                 <td>{renderStatus(bill.status)}</td>
+                <td>{renderConfidence(bill.confidence)}</td>
                 <td className="action-buttons-cell">
-                  <button
-                    onClick={e => { e.stopPropagation(); setSelectedBillIndex(index); setShowRawModal(true); }}
-                  >原文</button>
-                  <button
-                    onClick={e => { e.stopPropagation(); setSelectedBillIndex(index); setShowSettlementModal(true); }}
-                  >结算详情</button>
-                  <button
-                    onClick={e => { e.stopPropagation(); handleDeleteBill(bill.id); }}
-                    className="delete-button"
-                  >删除</button>
+                  <button onClick={() => { setSelectedBillIndex(index); setShowRawModal(true); }}>原文</button>
+                  <button onClick={() => { setSelectedBillIndex(index); setShowSettlementModal(true); }}>结算详情</button>
+                  <button onClick={() => handleDeleteBill(bill.id)} className="delete-button">删除</button>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
This commit introduces a 'Confidence Scoring System' to assess parsing accuracy.

- Adds `confidence` and `unparsed_text` columns to the `bills` table.
- Refactors `BetCalculator` to calculate a confidence score and return unparsed text.
- Updates backend API to handle the new data.
- Enhances the frontend to display confidence indicators in the bills list.
- Adds a warning and displays unparsed text in the details modal for low-confidence bills.