### PR TITLE
feat: Implement confidence scoring system and DB migration

### DIFF
--- a/backend/config.php
+++ b/backend/config.php
@@ -26,10 +26,10 @@ define('UPLOAD_DIR', __DIR__ . '/uploads/');
 
 // 5. Database Connection Settings
 // Replace the following placeholders with your actual database credentials.
-$db_host = 'localhost';     // Database host (e.g., '127.0.0.1' or 'localhost')
-$db_name = 'your_database_name'; // The name of your database
-$db_user = 'your_username';       // Your database username
-$db_pass = 'your_password';       // Your database password
+$db_host = '127.0.0.1';     // Database host (e.g., '127.0.0.1' or 'localhost')
+$db_name = 'lottery_app'; // The name of your database
+$db_user = 'lottery_user';       // Your database username
+$db_pass = 'password';       // Your database password
 
 // 6. Database Schema
 // The authoritative database schema is located in the `data_table_schema.sql` file.

--- a/backend/migrate.php
+++ b/backend/migrate.php
@@ -1,0 +1,46 @@
+<?php
+// A simple, one-time migration script to update the database schema.
+// This should be run from the command line: `php migrate.php`
+
+header('Content-Type: text/plain; charset=utf-8');
+
+require_once __DIR__ . '/config.php';
+
+try {
+    echo "🚀 Starting Database Migration...\n\n";
+
+    // 1. Connect to the database
+    $pdo = new PDO("mysql:host=$db_host;dbname=$db_name;charset=utf8mb4", $db_user, $db_pass);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    echo "✅ Successfully connected to database '$db_name'.\n";
+
+    // 2. Check for and add the 'confidence' column
+    $stmt = $pdo->query("SHOW COLUMNS FROM `bills` LIKE 'confidence'");
+    if ($stmt->rowCount() == 0) {
+        echo "   - Column 'confidence' not found. Adding it now...\n";
+        $pdo->exec("ALTER TABLE `bills` ADD `confidence` DECIMAL(5, 4) NULL COMMENT 'Confidence score of the parsing, from 0.0 to 1.0' AFTER `status`;");
+        echo "   ✅ Column 'confidence' added successfully.\n";
+    } else {
+        echo "   - Column 'confidence' already exists. Skipping.\n";
+    }
+
+    // 3. Check for and add the 'unparsed_text' column
+    $stmt = $pdo->query("SHOW COLUMNS FROM `bills` LIKE 'unparsed_text'");
+    if ($stmt->rowCount() == 0) {
+        echo "   - Column 'unparsed_text' not found. Adding it now...\n";
+        $pdo->exec("ALTER TABLE `bills` ADD `unparsed_text` TEXT NULL COMMENT 'Any text that was not successfully parsed' AFTER `confidence`;");
+        echo "   ✅ Column 'unparsed_text' added successfully.\n";
+    } else {
+        echo "   - Column 'unparsed_text' already exists. Skipping.\n";
+    }
+
+    echo "\n🎉 Database migration complete!\n";
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    die("❌ DATABASE ERROR: " . $e->getMessage() . "\n");
+} catch (Exception $e) {
+    http_response_code(500);
+    die("❌ GENERAL ERROR: " . $e->getMessage() . "\n");
+}
+?>


### PR DESCRIPTION
This commit introduces a 'Confidence Scoring System' to assess parsing accuracy and a migration script for safe deployment.

- Adds `confidence` and `unparsed_text` columns to the `bills` table via a new `migrate.php` script.
- Refactors `BetCalculator` to calculate a confidence score and return unparsed text.
- Updates backend API to handle the new data.
- Enhances the frontend to display confidence indicators and low-confidence warnings with unparsed text.
- Refactors frontend components for better modularity.