### PR TITLE
feat: Implement dual-view settlement modal and finalize parsing

### DIFF
--- a/backend/actions/update_settlement.php
+++ b/backend/actions/update_settlement.php
@@ -1,7 +1,7 @@
 <?php
-// Action: Update the settlement text for a single slip within a bill.
+// Action: Update the settlement result for a single slip and recalculate total cost.
 
-// Ensure the user is authenticated. The session is started in index.php.
+// Ensure the user is authenticated.
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
     echo json_encode(['success' => false, 'error' => 'User not authenticated.']);
@@ -15,67 +15,70 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 $data = json_decode(file_get_contents("php://input"), true);
+$user_id = $_SESSION['user_id'];
 
+// Validate input
 if (!isset($data['bill_id']) || !isset($data['slip_index']) || !isset($data['settlement_result'])) {
     http_response_code(400);
     echo json_encode(['success' => false, 'error' => 'Invalid input. Missing bill_id, slip_index, or settlement_result.']);
+    exit();
+}
+if (!is_array($data['settlement_result'])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'settlement_result must be a valid JSON object.']);
     exit();
 }
 
 $bill_id = $data['bill_id'];
 $slip_index = $data['slip_index'];
 $new_settlement_result = $data['settlement_result'];
-$user_id = $_SESSION['user_id'];
-
-if (!is_array($new_settlement_result)) {
-    http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'settlement_result must be a valid JSON object.']);
-    exit();
-}
 
 try {
     $pdo->beginTransaction();
 
-    // 1. Verify user owns the bill and lock the row for update
+    // 1. Fetch and lock the bill to ensure data consistency
     $stmt = $pdo->prepare("SELECT settlement_details FROM bills WHERE id = :bill_id AND user_id = :user_id FOR UPDATE");
     $stmt->execute([':bill_id' => $bill_id, ':user_id' => $user_id]);
     $bill = $stmt->fetch(PDO::FETCH_ASSOC);
 
     if (!$bill) {
+        $pdo->rollBack();
         http_response_code(404);
         echo json_encode(['success' => false, 'error' => 'Bill not found or you do not have permission to edit it.']);
-        $pdo->rollBack();
         exit();
     }
 
+    // 2. Decode the existing details
     $details = json_decode($bill['settlement_details'], true);
     if (json_last_error() !== JSON_ERROR_NONE || !is_array($details) || !isset($details['slips'])) {
-         http_response_code(500);
-         echo json_encode(['success' => false, 'error' => 'Could not parse existing settlement details.']);
-         $pdo->rollBack();
-         exit();
-    }
-
-    // 2. Check if the slip index is valid
-    if (!isset($details['slips'][$slip_index])) {
-        http_response_code(400);
-        echo json_encode(['success' => false, 'error' => 'Invalid slip index.']);
         $pdo->rollBack();
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'Could not parse existing settlement details.']);
         exit();
     }
 
-    // 3. Replace the old result with the new one
+    // 3. Validate the slip index
+    if (!isset($details['slips'][$slip_index])) {
+        $pdo->rollBack();
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Invalid slip index.']);
+        exit();
+    }
+
+    // 4. Replace the old result with the new one
     $details['slips'][$slip_index]['result'] = $new_settlement_result;
 
-    // 4. Recalculate the bill's total cost
+    // 5. Recalculate the bill's total cost from all slips
     $new_total_cost = 0;
     foreach ($details['slips'] as $slip) {
-        $new_total_cost += $slip['result']['summary']['total_cost'] ?? 0;
+        if (isset($slip['result']['summary']['total_cost'])) {
+            $new_total_cost += $slip['result']['summary']['total_cost'];
+        }
     }
     $details['summary']['total_cost'] = $new_total_cost;
-    $details['summary']['total_number_count'] = 0; // Recalculate if needed, omitted for now.
+    // Note: total_number_count could also be recalculated here if needed.
 
-    // 5. Save the updated details and total_cost back to the database
+    // 6. Encode the updated details and save back to the database
     $new_details_json = json_encode($details, JSON_UNESCAPED_UNICODE);
     $update_stmt = $pdo->prepare("UPDATE bills SET settlement_details = :details, total_cost = :cost WHERE id = :id");
     $update_stmt->execute([
@@ -84,12 +87,14 @@ try {
         ':id' => $bill_id
     ]);
 
+    // 7. Commit the transaction
     $pdo->commit();
 
     http_response_code(200);
     echo json_encode(['success' => true, 'message' => 'Settlement updated and total cost recalculated successfully.']);
 
 } catch (PDOException $e) {
+    $pdo->rollBack();
     error_log("Update settlement DB error: " . $e->getMessage());
     http_response_code(500);
     echo json_encode(['success' => false, 'error' => 'A server error occurred while updating the settlement.']);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -67,6 +67,58 @@ a:hover {
   border-radius: 4px;
   font-size: 0.8em;
   margin-right: 8px;
+  color: #333;
+}
+
+.region-tag {
+  background-color: #ffc107;
+  color: #333;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  font-weight: bold;
+  margin-right: 8px;
+}
+
+/* JSON Editor and Save Result Styles */
+.json-editor {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  background-color: #fdfdfd;
+  border: 1px solid #ccc;
+  color: #333;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.save-result {
+  margin-top: 8px;
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+.save-result.success {
+  background-color: #e6f7ff;
+  border: 1px solid #91d5ff;
+  color: #096dd9;
+}
+.save-result.error {
+  background-color: #fff1f0;
+  border: 1px solid #ffa39e;
+  color: #cf1322;
+}
+.save-result.info {
+  background-color: #f0f0f0;
+  border: 1px solid #d9d9d9;
+  color: #595959;
+}
+
+/* Tag Styles for Bet Slips */
+.time-tag {
+  background-color: #e0e0e0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  margin-right: 8px;
   color: #333; /* Ensure text is readable */
 }
 
@@ -108,4 +160,50 @@ a:hover {
   font-size: 0.8em;
   font-weight: bold;
   margin-right: 8px;
+}
+
+.injected-result {
+  color: #e74c3c; /* Red */
+  font-weight: bold;
+  margin: 0 4px;
+}
+
+/* View Toggle Styles */
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.view-toggle button {
+  background: #f0f0f0;
+  border: 1px solid #d9d9d9;
+  padding: 6px 12px;
+  cursor: pointer;
+  color: #595959;
+  transition: all 0.2s;
+}
+
+.view-toggle button:first-child {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.view-toggle button:last-child {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-left: none;
+}
+
+.view-toggle button.active {
+  background: var(--primary-color);
+  color: white;
+  border-color: var(--primary-color);
+  z-index: 2;
+}
+
+.view-toggle button:not(.active):hover {
+  background: #e6e6e6;
+  color: var(--primary-color);
 }


### PR DESCRIPTION
This commit delivers the final, feature-complete version of the settlement system.

- Implements a dual-view settlement modal with:
  - A 'card view' featuring a JSON editor to modify slip results.
  - A 'text view' that injects results directly into the original content.
- Restores and enhances the `update_settlement.php` API to support editing and recalculate totals within a transaction.
- Finalizes the `BetCalculator.php` parsing logic to correctly handle all specified bet formats (regions, timestamps, 'per-number' zodiac bets).
- Refactors frontend components for improved modularity and adds all necessary styling for the new UI.