### PR TITLE
feat: Make settlement modal responsive

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -430,7 +430,7 @@ button:active {
   box-sizing: border-box;
 }
 .modal-content.wide-modal {
-  max-width: 90vw;
+  max-width: 1100px; /* Capped for large screens */
 }
 .no-slips-message {
   padding: 20px;
@@ -615,28 +615,67 @@ p.success {
 /* ==============================
    响应式自适应优化
    ============================== */
+/* For medium screens and tablets, adjust slip layout */
+@media (max-width: 1024px) {
+  .bet-slip-card {
+    flex-wrap: wrap; /* Allow parts to wrap */
+  }
+  .slip-raw, .slip-result {
+    flex-basis: 100%; /* Each takes full width */
+    border-bottom: 1px solid var(--border);
+  }
+  .slip-cost {
+    flex-basis: 100%;
+    border-left: none; /* Remove side border */
+    border-top: 1px solid var(--border);
+    flex-direction: row; /* Align cost and actions horizontally */
+    justify-content: space-between;
+    align-items: center;
+  }
+  .slip-actions {
+    margin-top: 0;
+  }
+}
+
 @media (max-width: 900px) {
   #root { padding: 2vw 1vw; }
   .container { gap: 1.2rem; }
   main { padding: 1vw; }
   .panels-container { flex-direction: column; gap: 1vw; }
   .panel { padding: 1vw; }
-  .modal-content { padding: 1.2vw; }
+  .modal-content {
+    padding: 1.2vw;
+    /* On smaller devices, modal can become full-screen */
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+  .modal-close-button {
+    top: 1rem;
+    right: 1.2rem;
+  }
 }
 
+/* For smaller mobile screens */
 @media (max-width: 768px) {
   .bet-slip-card {
-    flex-direction: column;
+    flex-direction: column; /* Stack all items vertically */
   }
-  .slip-raw, .slip-cost {
+  .slip-raw, .slip-result, .slip-cost {
     border-right: none;
     border-left: none;
-  }
-  .slip-raw, .slip-result {
     border-bottom: 1px solid var(--border);
+    flex-basis: auto; /* Reset basis */
   }
   .slip-cost {
-    border-bottom: none;
+    border-bottom: none; /* Last item has no border */
+    flex-direction: column; /* Center content vertically */
+    padding: 1rem;
+  }
+  .slip-actions {
+    margin-top: 1rem;
   }
 }
 
@@ -644,9 +683,17 @@ p.success {
   #root { padding: 1vw 0.5vw; }
   main { padding: 0.5vw; }
   .panel { min-width: 0; padding: 1vw; }
-  .multi-details-summary, .single-bet-section { padding: 1vw; }
+  .multi-details-summary, .single-bet-section {
+    padding: 0.75rem;
+    flex-direction: column; /* Stack summary items */
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  .summary-divider {
+    display: none; /* Hide dividers when stacked */
+  }
   .multi-slips-table, .settlement-table, .bills-table {
-    font-size: 0.96em;
+    font-size: 0.92em; /* Slightly smaller font for tables */
   }
   .raw-content-panel { font-size: 0.96em; max-height: 180px; }
   .lottery-banner { padding: 1vw; font-size: 0.98em; }


### PR DESCRIPTION
Refactored the CSS for the settlement details modal to ensure it is fully responsive across all screen sizes.

- Capped the modal's max-width on large desktop screens to prevent it from becoming too wide.
- Added a new media query for tablet-sized screens (1024px) to create a better layout transition for the bet slip cards.
- Enhanced existing media queries for mobile devices to improve readability by adjusting font sizes, padding, and layout stacking.