### PR TITLE
fix: Resolve critical settlement bugs and improve parsing

### DIFF
--- a/backend/lib/BetCalculator.php
+++ b/backend/lib/BetCalculator.php
@@ -12,7 +12,8 @@ class BetCalculator {
         $text = $betting_slip_text;
 
         // 1. Unified Zodiac "Per Number" Parsing (Handles both "数各" and "各数")
-        $pattern = '/([\p{Han},，\s]+?)(?:数各|各数)\s*([\p{Han}\d]+)\s*[元块]?/u';
+        // This regex now correctly handles multiple bet expressions on a single line by looking for a start-of-string or separator before matching.
+        $pattern = '/(?:^|[,，\s])\s*([\p{Han},，\s]+?)(?:数各|各数)\s*([\p{Han}\d]+)\s*[元块]?/u';
         if (preg_match_all($pattern, $text, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $zodiac_string = preg_replace('/[,，\s]/u', '', $match[1]);


### PR DESCRIPTION
This commit addresses several critical issues to improve the stability and correctness of the application:

1.  **Fix `update_settlement.php` Crash**: Implemented robust `try...catch` error handling to prevent the script from crashing on invalid data. It now always returns a valid JSON response, fixing the "Unexpected end of JSON input" error on the frontend. The recalculation logic was also improved to update all summary fields (`total_cost`, `total_winnings`, `net_result`) for data consistency.

2.  **Fix Multi-Bet Parsing**: Corrected the regular expression in `BetCalculator.php` to accurately parse multiple zodiac bet expressions from a single line of text, preventing data corruption.

3.  **Update Settlement Logic**: The settlement calculation in `BetCalculator.php` now correctly uses only the 7th lottery number (the "special number") for determining wins.

4.  **Update Frontend UI**: The settlement modal in `SettlementModal.jsx` now displays the `net_result` (win/loss), with corresponding CSS styles in `App.css` to visually distinguish between a win and a loss.