### PR TITLE
feat: Implement user-specific winning rates

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -137,7 +137,7 @@ if ($raw_email_content === false) {
     echo json_encode(['success' => false, 'error' => 'Could not read uploaded email file.']);
     exit();
 }
-$stmt = $pdo->prepare("SELECT id FROM users WHERE email = :email");
+$stmt = $pdo->prepare("SELECT id, winning_rate FROM users WHERE email = :email");
 $stmt->execute([':email' => $user_email]);
 $user = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$user) {
@@ -146,6 +146,7 @@ if (!$user) {
     exit();
 }
 $user_id = $user['id'];
+$user_winning_rate = (float)($user['winning_rate'] ?? 45.0);
 
 // 邮件正文处理
 $detected_charset = null;
@@ -202,7 +203,8 @@ if ($parsed_bill !== null && !empty($parsed_bill['slips'])) {
 
     // If we have results, perform auto-settlement
     if (!empty($lottery_results_map)) {
-        $settled_bill = BetCalculator::settle($parsed_bill, $lottery_results_map);
+        // Pass the user-specific winning rate to the settle method
+        $settled_bill = BetCalculator::settle($parsed_bill, $lottery_results_map, $user_winning_rate);
         $settlement_details = json_encode($settled_bill, JSON_UNESCAPED_UNICODE);
         $status = 'settled'; // Mark as settled immediately
     } else {

--- a/backend/actions/register.php
+++ b/backend/actions/register.php
@@ -22,11 +22,23 @@ if (!isset($data['password']) || empty($data['password'])) {
 
 $email = $data['email'];
 $password_hash = password_hash($data['password'], PASSWORD_DEFAULT);
+$winning_rate = $data['winning_rate'] ?? 45; // Default to 45 if not provided
+
+// Validate the winning rate to ensure it's one of the allowed values
+if (!in_array($winning_rate, [45, 47])) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Invalid winning rate. Must be 45 or 47.']);
+    exit();
+}
 
 try {
     // The $pdo variable is inherited from index.php
-    $stmt = $pdo->prepare("INSERT INTO users (email, password) VALUES (:email, :password)");
-    $stmt->execute([':email' => $email, ':password' => $password_hash]);
+    $stmt = $pdo->prepare("INSERT INTO users (email, password, winning_rate) VALUES (:email, :password, :winning_rate)");
+    $stmt->execute([
+        ':email' => $email,
+        ':password' => $password_hash,
+        ':winning_rate' => $winning_rate
+    ]);
 
     http_response_code(201);
     echo json_encode(['success' => true, 'message' => 'User registered successfully.']);

--- a/backend/data_table_schema.sql
+++ b/backend/data_table_schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `username` VARCHAR(255) NULL UNIQUE,
   `email` VARCHAR(255) NOT NULL UNIQUE,
   `password` VARCHAR(255) NOT NULL,
+  `winning_rate` DECIMAL(5, 2) NOT NULL DEFAULT 45.00 COMMENT 'The winning rate for the user, e.g., 45.00 or 47.00',
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/backend/lib/BetCalculator.php
+++ b/backend/lib/BetCalculator.php
@@ -168,10 +168,9 @@ class BetCalculator {
         return 0;
     }
 
-    public static function settle(array $bill_details, array $lottery_results_map): array {
+    public static function settle(array $bill_details, array $lottery_results_map, float $winning_rate = 45.0): array {
         $settled_details = $bill_details;
         $total_winnings = 0;
-        $winning_rate = 45; // Standard rate for the special number
 
         // Get the arrays of winning numbers for each region
         $hk_numbers = $lottery_results_map['香港'] ?? null;

--- a/frontend/src/components/AuthModal.jsx
+++ b/frontend/src/components/AuthModal.jsx
@@ -5,6 +5,7 @@ function AuthModal({ onClose }) {
   const [isLoginView, setIsLoginView] = useState(true);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [winningRate, setWinningRate] = useState(45); // Add state for winning rate
   const [error, setError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const { login } = useAuth();
@@ -39,7 +40,7 @@ function AuthModal({ onClose }) {
       const response = await fetch('/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email, password, winning_rate: winningRate }),
       });
       const data = await response.json();
       if (data.success) {
@@ -81,6 +82,19 @@ function AuthModal({ onClose }) {
               autoComplete={isLoginView ? "current-password" : "new-password"}
             />
           </div>
+          {!isLoginView && (
+            <div>
+              <label htmlFor="winning_rate">赔率选择：</label>
+              <select
+                id="winning_rate"
+                value={winningRate}
+                onChange={(e) => setWinningRate(e.target.value)}
+              >
+                <option value="45">45</option>
+                <option value="47">47</option>
+              </select>
+            </div>
+          )}
           <button type="submit">{isLoginView ? '登录' : '注册'}</button>
         </form>
         {error && <p className="error">{error}</p>}


### PR DESCRIPTION
This commit introduces a new feature allowing users to select their winning rate (45x or 47x) during registration. This rate is then used for all their subsequent bet settlements.

- **Database**: Added a `winning_rate` column to the `users` table.
- **Backend**:
  - Updated the registration script (`register.php`) to accept and store the `winning_rate`.
  - Modified the settlement script (`email_upload.php`) to fetch the user's rate from the database.
  - Updated the `BetCalculator` to accept the winning rate as a parameter, removing the hardcoded value.
- **Frontend**: Added a dropdown menu to the registration form (`AuthModal.jsx`) for users to select their desired rate.