### PR TITLE
feat: Improve backend logic and settlement calculations

### DIFF
--- a/backend/lib/BetCalculator.php
+++ b/backend/lib/BetCalculator.php
@@ -12,7 +12,8 @@ class BetCalculator {
         $text = $betting_slip_text;
 
         // 1. Unified Zodiac "Per Number" Parsing (Handles both "数各" and "各数")
-        $pattern = '/([\p{Han},，\s]+?)(?:数各|各数)\s*([\p{Han}\d]+)\s*[元块]?/u';
+        // This regex now correctly handles multiple bet expressions on a single line by looking for a start-of-string or separator before matching.
+        $pattern = '/(?:^|[,，\s])\s*([\p{Han},，\s]+?)(?:数各|各数)\s*([\p{Han}\d]+)\s*[元块]?/u';
         if (preg_match_all($pattern, $text, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $zodiac_string = preg_replace('/[,，\s]/u', '', $match[1]);
@@ -170,22 +171,36 @@ class BetCalculator {
     public static function settle(array $bill_details, array $lottery_results_map): array {
         $settled_details = $bill_details;
         $total_winnings = 0;
-        $winning_rate = 45;
+        $winning_rate = 45; // Default winning rate
+
+        // Get the arrays of winning numbers for each region
         $hk_numbers = $lottery_results_map['香港'] ?? null;
         $nm_numbers = $lottery_results_map['新澳门'] ?? null;
 
+        // Extract the special number (7th number) for each region
+        $hk_special_number = isset($hk_numbers) && count($hk_numbers) >= 7 ? $hk_numbers[6] : null;
+        $nm_special_number = isset($nm_numbers) && count($nm_numbers) >= 7 ? $nm_numbers[6] : null;
+
         foreach ($settled_details['slips'] as &$slip) {
             $region = $slip['region'] ?? '';
-            $winning_numbers = (strpos($region, '香港') !== false || strpos($region, '港') !== false) ? $hk_numbers : $nm_numbers;
-            if ($winning_numbers === null) continue;
             $slip_winnings = 0;
+
+            // Determine which special number to use based on the slip's region
+            $special_number = (strpos($region, '香港') !== false || strpos($region, '港') !== false) ? $hk_special_number : $nm_special_number;
+
+            // If there's no special number for this region, skip settlement for this slip
+            if ($special_number === null) {
+                continue;
+            }
+
             if (isset($slip['result']['number_bets'])) {
                 foreach ($slip['result']['number_bets'] as &$bet) {
                     $bet['winning_numbers'] = [];
                     $bet['winnings'] = 0;
                     if (isset($bet['cost_per_number'])) {
                         foreach ($bet['numbers'] as $number) {
-                            if (in_array($number, $winning_numbers)) {
+                            // Check if the bet number matches the special number
+                            if ($number == $special_number) {
                                 $win_amount = $bet['cost_per_number'] * $winning_rate;
                                 $bet['winnings'] += $win_amount;
                                 $bet['winning_numbers'][] = $number;
@@ -200,7 +215,12 @@ class BetCalculator {
             $total_winnings += $slip_winnings;
         }
         unset($slip);
+
+        // Calculate total winnings and the net result (win/loss)
         $settled_details['summary']['total_winnings'] = $total_winnings;
+        $total_cost = $settled_details['summary']['total_cost'] ?? 0;
+        $settled_details['summary']['net_result'] = $total_winnings - $total_cost;
+
         return $settled_details;
     }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -333,6 +333,11 @@ button:active {
   color: var(--primary-hover);
   font-weight: bold;
 }
+
+.losing-row {
+  color: var(--error) !important;
+  font-weight: bold;
+}
 .summary-divider {
   color: var(--border);
   font-weight: normal;

--- a/frontend/src/components/modals/SettlementModal.jsx
+++ b/frontend/src/components/modals/SettlementModal.jsx
@@ -224,6 +224,18 @@ function SettlementModal({ open, bill, onClose, onSaveSuccess }) {
                   <span className="winning-row">{summary.total_winnings} 元</span>
                 </>
               )}
+              {/* Display Net Result (Win/Loss) */}
+              {typeof summary.net_result === 'number' && (
+                  <>
+                      <span className="summary-divider">|</span>
+                      <strong className={summary.net_result >= 0 ? 'winning-row' : 'losing-row'}>
+                          {summary.net_result >= 0 ? '净赢' : '净输'}:
+                      </strong>
+                      <span className={summary.net_result >= 0 ? 'winning-row' : 'losing-row'}>
+                          {summary.net_result} 元
+                      </span>
+                  </>
+              )}
             </div>
           </>
         )}
@@ -243,6 +255,18 @@ function SettlementModal({ open, bill, onClose, onSaveSuccess }) {
                   <strong className="winning-row">总计中奖:</strong>
                   <span className="winning-row">{summary.total_winnings} 元</span>
                 </>
+              )}
+              {/* Display Net Result (Win/Loss) in Text View */}
+              {typeof summary.net_result === 'number' && (
+                  <>
+                      <span className="summary-divider">|</span>
+                      <strong className={summary.net_result >= 0 ? 'winning-row' : 'losing-row'}>
+                          {summary.net_result >= 0 ? '净赢' : '净输'}:
+                      </strong>
+                      <span className={summary.net_result >= 0 ? 'winning-row' : 'losing-row'}>
+                          {summary.net_result} 元
+                      </span>
+                  </>
               )}
               <button onClick={() => setViewMode('card')} className="action-button edit summary-edit-button" title="切换到卡片视图进行编辑">编辑结算</button>
             </div>


### PR DESCRIPTION
This commit implements the first part of the restoration and improvement plan, focusing on critical backend logic fixes.

- **Fix Bet Parsing**: Corrected the regular expression in `BetCalculator.php` to accurately parse multiple zodiac bet expressions from a single line of text, resolving a bug where some bets were ignored.
- **Update Settlement Calculation**: The settlement logic in `BetCalculator.php` has been updated to base win calculations *only* on the 7th lottery number (the "special number").
- **Add Net Result**: The settlement summary now includes a `net_result` (win/loss) calculation, providing a clearer financial outcome.
- **Display Net Result**: The frontend `SettlementModal.jsx` has been updated to display this new net win/loss result, with distinct styling for wins and losses.