### PR TITLE
feat: Make Gemini API key database-driven

### DIFF
--- a/backend/actions/email_upload.php
+++ b/backend/actions/email_upload.php
@@ -130,6 +130,12 @@ if ($_FILES['raw_email_file']['error'] !== UPLOAD_ERR_OK) {
     exit();
 }
 
+// Fetch Gemini API key from the database
+$stmt_key = $pdo->prepare("SELECT setting_value FROM application_settings WHERE setting_name = 'gemini_api_key'");
+$stmt_key->execute();
+$gemini_api_key_row = $stmt_key->fetch(PDO::FETCH_ASSOC);
+$gemini_api_key = $gemini_api_key_row ? $gemini_api_key_row['setting_value'] : null;
+
 $user_email = $_POST['user_email'];
 $file_tmp_path = $_FILES['raw_email_file']['tmp_name'];
 $raw_email_content = file_get_contents($file_tmp_path);

--- a/backend/actions/update_setting.php
+++ b/backend/actions/update_setting.php
@@ -1,0 +1,67 @@
+<?php
+session_start();
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/db.php';
+
+header('Content-Type: application/json');
+
+// 1. Authentication Check: Ensure the user is logged in.
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401); // Unauthorized
+    echo json_encode(['success' => false, 'error' => 'Authentication required. Please log in.']);
+    exit();
+}
+
+// 2. Input Validation: Check for required POST data.
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(['success' => false, 'error' => 'Invalid request method.']);
+    exit();
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+if (!isset($data['setting_name']) || !isset($data['setting_value'])) {
+    http_response_code(400); // Bad Request
+    echo json_encode(['success' => false, 'error' => 'Missing required fields: setting_name and setting_value.']);
+    exit();
+}
+
+$setting_name = $data['setting_name'];
+$setting_value = $data['setting_value'];
+
+// 3. Security: Prevent updating critical or unknown settings via this endpoint.
+// For now, we only allow updating the 'gemini_api_key'.
+$allowed_settings = ['gemini_api_key'];
+if (!in_array($setting_name, $allowed_settings)) {
+    http_response_code(403); // Forbidden
+    echo json_encode(['success' => false, 'error' => 'You are not allowed to update this setting.']);
+    exit();
+}
+
+// 4. Database Update
+try {
+    $pdo = get_db_connection();
+    $sql = "UPDATE application_settings SET setting_value = :setting_value WHERE setting_name = :setting_name";
+    $stmt = $pdo->prepare($sql);
+
+    $stmt->execute([
+        ':setting_value' => $setting_value,
+        ':setting_name'  => $setting_name
+    ]);
+
+    if ($stmt->rowCount() > 0) {
+        http_response_code(200); // OK
+        echo json_encode(['success' => true, 'message' => 'Setting updated successfully.']);
+    } else {
+        // This could happen if the setting_name doesn't exist in the table.
+        http_response_code(404); // Not Found
+        echo json_encode(['success' => false, 'error' => 'Setting not found or value is already the same.']);
+    }
+
+} catch (PDOException $e) {
+    error_log("Setting update error: " . $e->getMessage());
+    http_response_code(500); // Internal Server Error
+    echo json_encode(['success' => false, 'error' => 'A database error occurred while updating the setting.']);
+}
+
+?>

--- a/backend/config.php
+++ b/backend/config.php
@@ -35,7 +35,7 @@ $db_pass = 'your_password';       // Your database password
 // The authoritative database schema is located in the `data_table_schema.sql` file.
 
 // 7. Gemini API Key
-// Replace 'YOUR_GEMINI_API_KEY' with your actual Gemini API key from Google AI Studio.
-$gemini_api_key = 'YOUR_GEMINI_API_KEY';
+// This is now stored in the `application_settings` table in the database
+// and can be managed from within the application.
 
 ?>

--- a/backend/data_table_schema.sql
+++ b/backend/data_table_schema.sql
@@ -41,6 +41,25 @@ CREATE TABLE IF NOT EXISTS `bills` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
+-- Table structure for table `application_settings`
+--
+CREATE TABLE IF NOT EXISTS `application_settings` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `setting_name` VARCHAR(255) NOT NULL UNIQUE,
+  `setting_value` TEXT NULL,
+  `description` TEXT NULL,
+  `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Default application settings
+--
+INSERT INTO `application_settings` (`setting_name`, `setting_value`, `description`)
+VALUES
+  ('gemini_api_key', 'YOUR_GEMINI_API_KEY', 'The API key for the Gemini AI service used for parsing corrections.')
+ON DUPLICATE KEY UPDATE `setting_name` = `setting_name`; -- Do nothing if the key already exists
+
+--
 -- Table structure for table `parsing_templates`
 --
 CREATE TABLE IF NOT EXISTS `parsing_templates` (


### PR DESCRIPTION
This commit refactors how the Gemini API key is managed, moving it from a hardcoded value in `config.php` to a dynamic setting stored in the database. This improves security and flexibility, allowing the key to be updated without code changes.

- Adds a new `application_settings` table to the database schema to store key-value pairs for application settings.
- Modifies the email processing workflow to fetch the `gemini_api_key` from the `application_settings` table at runtime.
- Removes the hardcoded `$gemini_api_key` variable from `config.php`.
- Adds a new secure API endpoint, `backend/actions/update_setting.php`, which allows an authenticated user to update the `gemini_api_key` in the database.