### PR TITLE
Fix: Improve lottery result parsing logic

### DIFF
--- a/backend/lib/LotteryParser.php
+++ b/backend/lib/LotteryParser.php
@@ -3,34 +3,43 @@
 class LotteryParser {
 
     /**
-     * Parses a text message to find lottery results.
+     * Parses a text message to find lottery results, accommodating variations.
      *
      * @param string $text The text of the message.
      * @return array|null An array with the parsed data, or null if no match.
      */
     public static function parse($text) {
-        // Regex for "新澳门六合彩" and "老澳21.30" formats
-        $pattern1 = '/(新澳门六合彩|老澳\d{2}\.\d{2})第:(\d+)\s*期开奖结果:\s*([\d\s]+)/u';
-        // Regex for "香港六合彩" format
-        $pattern2 = '/(香港六合彩)第:(\d+)\s*期开奖结果:\s*([\d\s]+)/u';
+        // A more robust regex that captures the essential parts and the rest of the line.
+        // It's less strict about the text between the issue number and the numbers.
+        $pattern = '/(新澳门六合彩|老澳\d{2}\.\d{2}|香港六合彩)\s*第:?\s*(\d+)\s*期(.*)/u';
 
         $matches = [];
-        if (preg_match($pattern1, $text, $matches) || preg_match($pattern2, $text, $matches)) {
+        if (preg_match($pattern, $text, $matches)) {
             $lotteryName = trim($matches[1]);
             $issueNumber = trim($matches[2]);
+            $remainingText = trim($matches[3]); // This contains the numbers part
 
-            // Extract and clean the numbers
-            $numbersStr = trim($matches[3]);
-            $numbers = preg_split('/\s+/', $numbersStr);
+            // Robustly extract all numbers from the remaining text.
+            preg_match_all('/\d+/', $remainingText, $numberMatches);
+            $numbers = !empty($numberMatches[0]) ? $numberMatches[0] : [];
 
-            // The subsequent lines for zodiacs and colors are not parsed here,
-            // as they can be derived from the numbers using GameData.
-            // This parser focuses on the core result data.
+            // Basic validation: A valid result must contain exactly 7 numbers.
+            if (count($numbers) !== 7) {
+                // Log an error or handle cases where number count is wrong.
+                error_log("LotteryParser: Expected 7 numbers, but found " . count($numbers) . " in text: \"$text\"");
+                return null;
+            }
+
+            // Ensure numbers are zero-padded (e.g., 1 -> 01)
+            $formattedNumbers = array_map(function($num) {
+                return str_pad($num, 2, '0', STR_PAD_LEFT);
+            }, $numbers);
+
 
             return [
                 'lottery_name' => $lotteryName,
                 'issue_number' => $issueNumber,
-                'numbers' => $numbers,
+                'numbers' => $formattedNumbers,
             ];
         }
 


### PR DESCRIPTION
This commit resolves a bug where the bot failed to parse lottery result messages from Telegram channels.

The root cause was an overly strict regular expression in `LotteryParser.php` that could not handle minor variations in the message format, such as different keywords (e.g., "开奖号码" vs. "开奖结果") or inconsistent whitespace.

The updated `LotteryParser.php` now features:
- A more flexible regular expression that captures the essential lottery name and issue number, then extracts numbers from the rest of the string.
- Robust number extraction that handles various delimiters (spaces, commas, etc.).
- Validation to ensure exactly seven numbers are found before accepting a result.
- Automatic zero-padding for single-digit numbers to maintain data consistency.

These changes significantly improve the reliability of the data pipeline, ensuring new lottery results are correctly saved to the database and displayed on the frontend.