### PR TITLE
feat: Implement user registration and approval system

### DIFF
--- a/backend/data_table_schema.sql
+++ b/backend/data_table_schema.sql
@@ -7,9 +7,11 @@
 --
 CREATE TABLE IF NOT EXISTS `users` (
   `id` INT AUTO_INCREMENT PRIMARY KEY,
-  `username` VARCHAR(255) NULL UNIQUE,
-  `email` VARCHAR(255) NOT NULL UNIQUE,
-  `password` VARCHAR(255) NOT NULL,
+  `telegram_id` BIGINT NULL UNIQUE COMMENT 'The user''s unique Telegram ID',
+  `username` VARCHAR(255) NULL,
+  `status` VARCHAR(50) NOT NULL DEFAULT 'pending' COMMENT 'User status: pending, approved, denied',
+  `email` VARCHAR(255) NULL UNIQUE,
+  `password` VARCHAR(255) NULL,
   `winning_rate` DECIMAL(5, 2) NOT NULL DEFAULT 45.00 COMMENT 'The user-specific winning rate, e.g., 45.00 or 47.00',
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -58,18 +60,3 @@ INSERT INTO `application_settings` (`setting_name`, `setting_value`, `descriptio
 VALUES
   ('gemini_api_key', 'YOUR_GEMINI_API_KEY', 'The API key for the Gemini AI service used for parsing corrections.')
 ON DUPLICATE KEY UPDATE `setting_name` = `setting_name`; -- Do nothing if the key already exists
-
---
--- Table structure for table `parsing_templates`
---
-CREATE TABLE IF NOT EXISTS `parsing_templates` (
-  `id` INT AUTO_INCREMENT PRIMARY KEY,
-  `user_id` INT NULL COMMENT 'NULL for global templates, or a user_id for user-specific ones',
-  `pattern` VARCHAR(1024) NOT NULL,
-  `type` VARCHAR(50) NOT NULL COMMENT 'e.g., "zodiac", "number_list" to know how to process the match',
-  `description` TEXT NULL COMMENT 'A description of what the pattern is for, can be AI-generated',
-  `priority` INT NOT NULL DEFAULT 100 COMMENT 'Order in which to try the pattern (lower is higher priority)',
-  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  UNIQUE KEY `user_pattern` (`user_id`, `pattern`(255)),
-  FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/lib/LotteryParser.php
+++ b/backend/lib/LotteryParser.php
@@ -3,73 +3,39 @@
 class LotteryParser {
 
     /**
-     * Parses a text message to find lottery results, using dynamic templates first.
+     * Parses a text message to find lottery results.
      *
      * @param string $text The text of the message.
-     * @param PDO $pdo The database connection object.
      * @return array|null An array with the parsed data, or null if no match.
      */
-    public static function parse($text, PDO $pdo) {
-        // 1. Try to parse using custom templates from the database
-        try {
-            $stmt = $pdo->query("SELECT pattern FROM parsing_templates WHERE type = 'lottery_result' ORDER BY priority ASC, id ASC");
-            $templates = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    public static function parse($text) {
+        // Use the hardcoded, robust regex for parsing.
+        $pattern = '/(新澳门六合彩|老澳\d{2}\.\d{2}|香港六合彩)\s*第:?\s*(\d+)\s*期(.*)/u';
 
-            foreach ($templates as $template) {
-                $pattern = $template['pattern'];
-                if (@preg_match($pattern, $text, $matches)) {
-                    // Custom templates are expected to capture 3 groups: name, issue, and numbers string.
-                    if (count($matches) === 4) {
-                        $lotteryName = trim($matches[1]);
-                        $issueNumber = trim($matches[2]);
-                        $numbersStr = trim($matches[3]);
-
-                        // Re-use the robust number extraction logic
-                        preg_match_all('/\d+/', $numbersStr, $numberMatches);
-                        $numbers = !empty($numberMatches[0]) ? $numberMatches[0] : [];
-
-                        if (count($numbers) === 7) {
-                            $formattedNumbers = array_map(fn($num) => str_pad($num, 2, '0', STR_PAD_LEFT), $numbers);
-                            return [
-                                'lottery_name' => $lotteryName,
-                                'issue_number' => $issueNumber,
-                                'numbers' => $formattedNumbers,
-                            ];
-                        }
-                    }
-                }
-            }
-        } catch (PDOException $e) {
-            error_log("LotteryParser: Database error fetching templates: " . $e->getMessage());
-            // Proceed to fallback on DB error
-        }
-
-        // 2. Fallback to the hardcoded, robust regex if no custom template matched
-        $fallback_pattern = '/(新澳门六合彩|老澳\d{2}\.\d{2}|香港六合彩)\s*第:?\s*(\d+)\s*期(.*)/u';
-
-        if (preg_match($fallback_pattern, $text, $matches)) {
+        if (preg_match($pattern, $text, $matches)) {
             $lotteryName = trim($matches[1]);
             $issueNumber = trim($matches[2]);
             $remainingText = trim($matches[3]); // This contains the numbers part
 
+            // Robustly extract all numbers from the remaining text.
             preg_match_all('/\d+/', $remainingText, $numberMatches);
             $numbers = !empty($numberMatches[0]) ? $numberMatches[0] : [];
 
+            // Basic validation: A valid result must contain exactly 7 numbers.
             if (count($numbers) === 7) {
+                // Ensure numbers are zero-padded (e.g., 1 -> 01)
                 $formattedNumbers = array_map(fn($num) => str_pad($num, 2, '0', STR_PAD_LEFT), $numbers);
+
                 return [
                     'lottery_name' => $lotteryName,
                     'issue_number' => $issueNumber,
                     'numbers' => $formattedNumbers,
                 ];
+            } else {
+                // Log failure if a potential lottery message was detected but didn't have 7 numbers.
+                error_log("LotteryParser: Expected 7 numbers, but found " . count($numbers) . " in text: \"$text\"");
             }
         }
-
-        // Log failure if a potential lottery message was detected but didn't have 7 numbers.
-        if (isset($numbers) && count($numbers) !== 7) {
-             error_log("LotteryParser: Expected 7 numbers, but found " . count($numbers) . " in text: \"$text\"");
-        }
-
 
         return null;
     }


### PR DESCRIPTION
This commit removes the previous template management feature and replaces it with a new, robust user registration and approval workflow.

Key features:
- A public `/register` command allows new users to request access.
- When a user registers, a notification with inline 'Approve' and 'Deny' buttons is sent to the administrator.
- The bot handles the admin's button clicks, updates the user's status in the database, and notifies both the admin and the user of the outcome.
- The database schema (`users` table) has been updated with `telegram_id` and `status` columns to support this new flow.
- Admin commands (`/listusers`, `/deluser`) have been updated to align with the new system.
- All obsolete template management code has been removed.

This also includes a critical fix to the bot's permission model, ensuring it can read messages from channels while keeping admin commands secure.