### PR TITLE
Configure Vite proxy to enable frontend-backend communication.

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,27 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      // A list of all backend actions that should be proxied.
+      // This ensures that the frontend, running on the Vite dev server,
+      // can communicate with the backend PHP server during local development.
+      '/login': 'http://localhost:8000',
+      '/register': 'http://localhost:8000',
+      '/check_session': 'http://localhost:8000',
+      '/logout': 'http://localhost:8000',
+      '/get_lottery_results': 'http://localhost:8000',
+      '/get_game_data': 'http://localhost:8000',
+      '/get_bills': 'http://localhost:8000',
+      '/delete_bill': 'http://localhost:8000',
+      '/update_settlement': 'http://localhost:8000',
+      // Adding all other available actions to be safe.
+      '/is_user_registered': 'http://localhost:8000',
+      '/email_upload': 'http://localhost:8000',
+      '/process_text': 'http://localhost:8000',
+    },
+  },
+});

--- a/jules-scratch/verification/verify_login_error.py
+++ b/jules-scratch/verification/verify_login_error.py
@@ -1,0 +1,37 @@
+from playwright.sync_api import Page, expect
+
+def test_login_with_invalid_credentials(page: Page):
+    """
+    This test verifies that when a user tries to log in with invalid credentials,
+    the application displays the correct error message from the backend,
+    proving that the frontend-backend communication is working via the proxy.
+    """
+    # 1. Arrange: Go to the application's homepage.
+    page.goto("http://localhost:5174/")
+
+    # 2. Act: Open the login modal.
+    login_button = page.get_by_role("button", name="登录 / 注册")
+    expect(login_button).to_be_visible()
+    login_button.click()
+
+    # 3. Act: Fill in the login form with invalid credentials.
+    email_input = page.get_by_label("邮箱：")
+    password_input = page.get_by_label("密码：")
+    submit_button = page.get_by_role("button", name="登录")
+
+    expect(email_input).to_be_visible()
+    email_input.fill("test@example.com")
+    password_input.fill("wrongpassword")
+
+    # 4. Act: Submit the form.
+    submit_button.click()
+
+    # 5. Assert: Check for the backend's error message.
+    # The key is to see the "Invalid email or password." message, which comes
+    # from the backend `login.php` script. This confirms the proxy is working.
+    error_message = page.locator("p.error")
+    expect(error_message).to_have_text("Invalid email or password.")
+    expect(error_message).to_be_visible()
+
+    # 6. Screenshot: Capture the final result for visual verification.
+    page.screenshot(path="jules-scratch/verification/verification.png")


### PR DESCRIPTION
The application was experiencing connection errors (403 Forbidden, 525 SSL Handshake Failed) during local development. This was caused by the frontend's Vite development server not being configured to forward API requests to the backend PHP server.

This commit adds a server proxy configuration to `frontend/vite.config.js`. The proxy forwards all API requests (e.g., /login, /get_lottery_results) to the backend server, assumed to be running on `http://localhost:8000`. This resolves the communication issues and allows the application to function correctly in a local development environment.