### PR TITLE
Fix: Resolve connection errors and improve registration stability

### DIFF
--- a/frontend/public/_worker.js
+++ b/frontend/public/_worker.js
@@ -1,7 +1,9 @@
 export default {
   async fetch(request, env, ctx) {
-    const backendHost = 'https://wenge.cloudns.ch';
     const url = new URL(request.url);
+    // The backend is hosted on the same domain as the worker.
+    // We use the request's URL origin to dynamically determine the backend host.
+    const backendHost = url.origin;
     const { pathname } = url;
 
     // The origin of the frontend application making the request


### PR DESCRIPTION
This commit addresses two critical issues:
1.  Connection Errors (525, 403): The Cloudflare Worker script (`frontend/public/_worker.js`) was using a hardcoded and incorrect backend host. This has been updated to dynamically use the request's origin, ensuring that API requests are correctly routed to the proper backend in any environment. This resolves the `525 SSL Handshake Failed` and subsequent `403 Forbidden` errors.

2.  Registration Error (500): The registration script (`backend/actions/register.php`) could crash if it failed to send a Telegram notification. This has been fixed by wrapping the notification logic in a `try-catch` block, ensuring that a notification failure is logged without causing a `500 Internal Server Error`, making the registration process more robust.