### PR TITLE
fix: Add composer.json to backend

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "vendor/email-parser-backend",
+    "description": "Backend for the email parser application.",
+    "type": "project",
+    "license": "proprietary",
+    "authors": [
+        {
+            "name": "Jules",
+            "email": "jules@agent.com"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
This commit adds a basic composer.json file to the `/backend` directory.

The deployment process runs `composer install`, which requires this file to be present, even if no dependencies are listed. Adding this empty-but-valid file resolves the deployment error.