### PR TITLE
fix: Add detailed logging to init.php for final debugging

### DIFF
--- a/backend/init.php
+++ b/backend/init.php
@@ -1,43 +1,60 @@
 <?php
-// --- Custom Session Handling for Shared Hosting ---
-// Define a dedicated, writable directory for session files within our project.
-$session_path = __DIR__ . '/sessions';
+// --- Custom Session Handling & Logging ---
+$log_file = __DIR__ . '/debug.log';
+// Clear the log for each new request to get clean data
+file_put_contents($log_file, "--- NEW REQUEST AT " . date('Y-m-d H:i:s') . " ---\n");
 
-// Check if the session directory exists. If not, try to create it.
-if (!is_dir($session_path)) {
-    // The third parameter 'true' allows the creation of nested directories if needed.
-    // The mode 0755 is a common permission setting for web directories.
-    if (!mkdir($session_path, 0755, true) && !is_dir($session_path)) {
-        // If mkdir fails, throw a clear exception.
-        // This will be caught by our global exception handler and returned as a clean JSON error.
-        throw new RuntimeException(sprintf('错误：无法创建Session目录 "%s"。请检查服务器权限。', $session_path));
+try {
+    file_put_contents($log_file, "Step 1: init.php script started.\n", FILE_APPEND);
+
+    // Define a dedicated, writable directory for session files.
+    $session_path = __DIR__ . '/sessions';
+    file_put_contents($log_file, "Step 2: Session path defined as: " . $session_path . "\n", FILE_APPEND);
+
+    // Check if the session directory exists.
+    if (!is_dir($session_path)) {
+        file_put_contents($log_file, "Step 3: Session directory does not exist. Attempting to create it.\n", FILE_APPEND);
+        // The third parameter 'true' allows the creation of nested directories.
+        if (!mkdir($session_path, 0755, true) && !is_dir($session_path)) {
+            throw new RuntimeException(sprintf('Fatal: Could not create session directory "%s".', $session_path));
+        }
+        file_put_contents($log_file, "Step 4: Session directory created successfully.\n", FILE_APPEND);
+    } else {
+        file_put_contents($log_file, "Step 3: Session directory already exists.\n", FILE_APPEND);
     }
+
+    // Set the session save path.
+    session_save_path($session_path);
+    file_put_contents($log_file, "Step 5: Session save path set successfully.\n", FILE_APPEND);
+
+    // Start session
+    if (session_status() == PHP_SESSION_NONE) {
+        file_put_contents($log_file, "Step 6: Attempting to start session...\n", FILE_APPEND);
+        session_start();
+        file_put_contents($log_file, "Step 7: session_start() completed.\n", FILE_APPEND);
+    } else {
+        file_put_contents($log_file, "Step 6: Session already active.\n", FILE_APPEND);
+    }
+
+} catch (Throwable $e) {
+    // If any of the above steps fail, log the error and exit cleanly.
+    file_put_contents($log_file, "FATAL ERROR in session handling: " . $e->getMessage() . "\n", FILE_APPEND);
+    // Exit with a JSON response even in this critical path
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Server configuration error during session initialization.']);
+    exit;
 }
 
-// Set the session save path *before* starting the session.
-session_save_path($session_path);
+// --- Standard Headers & Handlers (from here on, things should be safe) ---
 
-
-// Start session
-if (session_status() == PHP_SESSION_NONE) {
-    // Now, session_start() will use the reliable path we just defined.
-    session_start();
-}
-
-// Set CORS headers
-header("Access-Control-Allow-Origin: *"); // In production, restrict this to your frontend domain
+header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Credentials: true");
 header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
 header("Access-Control-Allow-Headers: Content-Type, Authorization, X-Worker-Secret");
 
-// Handle OPTIONS preflight requests
-if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
-    exit(0);
-}
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') { exit(0); }
 
-// --- Robust Error and Exception Handling ---
-
-// JSON response helper function that prevents errors if headers are already sent
 function json_response($data, $statusCode = 200) {
     if (!headers_sent()) {
         http_response_code($statusCode);
@@ -47,59 +64,40 @@ function json_response($data, $statusCode = 200) {
     exit;
 }
 
-// Set a global exception handler that will catch any uncaught exceptions
 set_exception_handler(function(Throwable $e) {
-    // In a real app, you would log the error: error_log($e->getMessage() . "\n" . $e->getTraceAsString());
-    json_response(['error' => 'An internal server error occurred. Please contact support.'], 500);
+    global $log_file;
+    file_put_contents($log_file, "GLOBAL EXCEPTION: " . $e->getMessage() . "\n" . $e->getTraceAsString() . "\n", FILE_APPEND);
+    json_response(['error' => 'An internal server error occurred.'], 500);
 });
 
-// Set an error handler to convert all errors (warnings, notices, etc.) to exceptions
 set_error_handler(function($severity, $message, $file, $line) {
-    if (!(error_reporting() & $severity)) {
-        // This error code is not included in error_reporting
-        return;
-    }
+    if (!(error_reporting() & $severity)) { return; }
     throw new ErrorException($message, 0, $severity, $file, $line);
 });
 
-// Ensure errors are not displayed to the user, as we handle them ourselves.
 ini_set('display_errors', '0');
 error_reporting(E_ALL);
 
-
-// --- Configuration Loading ---
-
-// Load environment variables from .env file
 function load_env($path) {
-    if (!file_exists($path)) {
-        throw new Exception(".env file not found at " . $path);
-    }
+    if (!file_exists($path)) { throw new Exception(".env file not found at " . $path); }
     $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
     foreach ($lines as $line) {
-        if (strpos(trim($line), '#') === 0) {
-            continue;
-        }
+        if (strpos(trim($line), '#') === 0) continue;
         list($name, $value) = explode('=', $line, 2);
         $_ENV[trim($name)] = trim($value);
     }
 }
 
 load_env(__DIR__ . '/.env');
-
-
-// --- Database Connection ---
+file_put_contents($log_file, "Step 8: .env file loaded.\n", FILE_APPEND);
 
 $pdo = null;
 try {
     $host = $_ENV['DB_HOST'] ?? null;
     $dbname = $_ENV['DB_NAME'] ?? null;
     $user = $_ENV['DB_USER'] ?? null;
-    $pass = $_ENV['DB_PASS'] ?? ''; // Default to empty string if not set
-
-    if (!$host || !$dbname || !$user) {
-        throw new Exception("Database configuration is incomplete in the .env file.");
-    }
-
+    $pass = $_ENV['DB_PASS'] ?? '';
+    if (!$host || !$dbname || !$user) { throw new Exception("Database configuration is incomplete."); }
     $dsn = "mysql:host=$host;dbname=$dbname;charset=utf8mb4";
     $options = [
         PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
@@ -107,9 +105,8 @@ try {
         PDO::ATTR_EMULATE_PREPARES   => false,
     ];
     $pdo = new PDO($dsn, $user, $pass, $options);
+    file_put_contents($log_file, "Step 9: Database connection successful.\n", FILE_APPEND);
 } catch (Throwable $e) {
-    // Re-throw the exception to be caught by our global exception handler,
-    // which will log it and return a generic JSON error message.
     throw $e;
 }
 ?>


### PR DESCRIPTION
This commit provides a final attempt to diagnose the persistent 502 Bad Gateway errors.

The `init.php` file has been instrumented with detailed step-by-step logging to a `debug.log` file. This will trace the execution flow of the session and configuration initialization, allowing us to pinpoint the exact line of code that is failing on the production server.

This is a temporary debugging measure. The logging will be removed once the root cause is identified and resolved.