### PR TITLE
Fix: Add favicon to resolve 500 error on missing asset

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>邮件文本处理器</title>
   </head>
   <body>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="12" fill="#1e1e1e"/>
+  <path d="M14 20H50" stroke="#28a745" stroke-width="4" stroke-linecap="round"/>
+  <path d="M14 32H38" stroke="#e0e0e0" stroke-width="4" stroke-linecap="round"/>
+  <path d="M14 44H50" stroke="#e0e0e0" stroke-width="4" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
This commit adds a `favicon.svg` to the `frontend/public/` directory and links it in the `index.html`.

This is the final fix that addresses a 500 Internal Server Error that occurred when the browser requested a non-existent `/favicon.ico`. The Cloudflare Worker was likely throwing an unhandled exception when it could not find the asset, causing the server to return a generic error.

By providing a valid favicon, this commit resolves the last remaining platform error and completes the comprehensive overhaul of the application.