### PR TITLE
fix: Add .htaccess to fix backend routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,7 @@ This project uses a modern architecture:
 ### Backend on Serv00
 
 1.  **Upload the `backend` directory** to your Serv00 server's public web directory (e.g., `public_html`).
-2.  **Configure URL Rewriting**: You need to configure your web server (e.g., Apache) to route all requests for non-existent files to `index.php`. Create a `.htaccess` file in the `backend` directory with the following content:
-    ```apache
-    RewriteEngine On
-    RewriteBase /
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule . /index.php [L]
-    ```
+2.  **Ensure URL Rewriting is Enabled**: The included `.htaccess` file automatically configures the Apache server to correctly route all requests to `index.php`. Make sure this file is uploaded with the rest of the `backend` directory. This is crucial for the API to work correctly.
 3.  **Set up the `.env` file** on the server with your production secrets. **Do not upload your `.env` file directly.**
 4.  Set the Telegram webhook to point to your live server URL (`https://wenge.cloudns.ch`) as described above.
 

--- a/backend/.htaccess
+++ b/backend/.htaccess
@@ -1,0 +1,9 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+
+  # Redirect all requests to non-existent files/directories to index.php
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule . /index.php [L]
+</IfModule>


### PR DESCRIPTION
This commit resolves a 502 Bad Gateway error on the production server by adding a `.htaccess` file to the `backend` directory.

This file configures the Apache server to use URL rewriting, directing all API requests to the `index.php` front controller. This ensures that the backend router can correctly handle clean URLs (e.g., `/api/get_numbers.php`) and return the proper JSON responses instead of an HTML error page.

The `README.md` has also been updated to reflect that this configuration is now included by default.