### PR TITLE
fix: Refactor to PATH_INFO routing to resolve 502 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This is a full-stack application that displays lottery numbers. The frontend is built with React and Vite, and the backend is a simple PHP application. It also includes a Telegram bot integration for updating the lottery numbers and a user authentication system.
 
-This project uses a modern architecture:
-- **Backend**: A PHP application using a "front controller" pattern (`index.php`) to route all API requests.
+This project uses a modern and reliable architecture:
+- **Backend**: A PHP application using a "front controller" pattern (`index.php`). It uses `PATH_INFO` for routing, which works on almost any server configuration without needing URL rewriting.
 - **Frontend**: A React application that leverages a Cloudflare Worker (`_worker.js`) to proxy API requests, solving CORS issues and simplifying deployment.
 
 ## Production URLs
@@ -67,7 +67,7 @@ This project uses a modern architecture:
     ```bash
     npm run dev
     ```
-    The application will be available at `http://localhost:5173`. The Vite development server is now configured to proxy all requests ending in `.php` to your local PHP backend.
+    The application will be available at `http://localhost:5173`. The Vite development server is configured to proxy requests for `.php` files to your local backend, rewriting them to use the `PATH_INFO` format (e.g., `/index.php/login.php`).
 
 ## Telegram Bot Integration
 
@@ -76,10 +76,10 @@ This project uses a modern architecture:
     - It will give you a unique token. Add this token to your `backend/.env` file.
 
 2.  **Set the Webhook**:
-    You need to tell Telegram where to send messages. The URL must point to your deployed backend, including the `/backend` path.
+    You need to tell Telegram where to send messages. The URL must point to your deployed backend's `index.php` router.
     Replace `YOUR_TELEGRAM_BOT_TOKEN` in the URL below.
     ```
-    https://api.telegram.org/bot<YOUR_TELEGRAM_BOT_TOKEN>/setWebhook?url=https://wenge.cloudns.ch/backend/telegram_webhook.php
+    https://api.telegram.org/bot<YOUR_TELEGRAM_BOT_TOKEN>/setWebhook?url=https://wenge.cloudns.ch/backend/index.php/telegram_webhook.php
     ```
 
 3.  **Update Lottery Numbers**:
@@ -93,7 +93,7 @@ This project uses a modern architecture:
 ### Backend on Serv00
 
 1.  **Upload the `backend` directory** to your Serv00 server's public web directory (e.g., `public_html`).
-2.  **Ensure URL Rewriting is Enabled**: The included `.htaccess` file automatically configures the Apache server to correctly route all requests to `index.php`. Make sure this file is uploaded with the rest of the `backend` directory. This is crucial for the API to work correctly.
+2.  **Server Configuration**: No special URL rewriting is needed. This application uses `PATH_INFO` routing, which is supported by default on most modern PHP servers. The `.htaccess` file is no longer required.
 3.  **Set up the `.env` file** on the server with your production secrets. **Do not upload your `.env` file directly.**
 4.  Set the Telegram webhook to point to your live server URL as described in the "Telegram Bot Integration" section.
 
@@ -101,7 +101,7 @@ This project uses a modern architecture:
 
 1.  **Push your code** to a GitHub repository.
 2.  **Confirm the Backend URL in the Worker**:
-    - The `frontend/public/_worker.js` file has been configured to detect any request ending in `.php` and proxy it to `https://wenge.cloudns.ch`.
+    - The `frontend/public/_worker.js` file has been configured to rewrite requests to use the `PATH_INFO` format (e.g., `.../index.php/login.php`) and proxy them to `https://wenge.cloudns.ch`.
 3.  **Create a new project** on Cloudflare Pages and connect it to your GitHub repository.
 4.  **Configure the build settings**:
     - **Framework preset**: `Vite`

--- a/backend/.htaccess
+++ b/backend/.htaccess
@@ -1,9 +1,0 @@
-<IfModule mod_rewrite.c>
-  RewriteEngine On
-
-  # This configuration makes the routing work correctly even when the
-  # project is deployed in a subdirectory.
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteRule . index.php [L]
-</IfModule>

--- a/backend/index.php
+++ b/backend/index.php
@@ -1,21 +1,20 @@
 <?php
-// A simple front-controller to route API requests.
+// A simple front-controller to route API requests using PATH_INFO.
 
 require_once __DIR__ . '/init.php';
 
-// --- Basic Router ---
-$request_uri = $_SERVER['REQUEST_URI'];
-$script_path = dirname($_SERVER['SCRIPT_NAME']);
+// --- PATH_INFO Router ---
+// This method is more reliable than URL rewriting on some shared hosts.
+// It expects URLs like /index.php/login.php
+$path_info = $_SERVER['PATH_INFO'] ?? '';
+$endpoint = basename(trim($path_info, '/'));
 
-// Remove the base path from the request URI to get the endpoint path
-if (strpos($request_uri, $script_path) === 0) {
-    $path = substr($request_uri, strlen($script_path));
-} else {
-    $path = $request_uri;
+// If no endpoint is found, it's a bad request.
+if (empty($endpoint)) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Not Found: No API endpoint specified.']);
+    exit;
 }
-
-// Get the final part of the path as the endpoint (e.g., 'login.php')
-$endpoint = basename(trim($path, '/'));
 
 // Start session for any endpoints that might need it
 session_start();

--- a/frontend/public/_worker.js
+++ b/frontend/public/_worker.js
@@ -8,8 +8,9 @@ export default {
       // The backend server URL for production.
       const backendUrl = 'https://wenge.cloudns.ch';
 
-      // Create a new URL to the backend, prepending the /backend path.
-      const newUrl = new URL(backendUrl + '/backend' + url.pathname + url.search);
+      // Create a new URL to the backend, adding /backend/index.php
+      // to use the PATH_INFO routing strategy.
+      const newUrl = new URL(backendUrl + '/backend/index.php' + url.pathname + url.search);
 
       // Create a new request to the backend, copying the original request's method, headers, and body.
       const newRequest = new Request(newUrl, {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,10 +6,12 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      // Proxy all requests ending in .php to the backend server
+      // Proxy all requests ending in .php to the backend server,
+      // rewriting the path to use the PATH_INFO routing strategy.
       '**/*.php': {
         target: 'http://localhost:8000',
         changeOrigin: true,
+        rewrite: (path) => `/index.php${path}`,
       },
     },
   },


### PR DESCRIPTION
This commit implements a more robust routing strategy to fix the persistent 502 Bad Gateway errors on the production server. The application now uses `PATH_INFO` routing, which is more reliable and less dependent on server-specific URL rewriting configurations.

- **Backend Router**: The `backend/index.php` router is updated to use the `$_SERVER['PATH_INFO']` variable to determine the API endpoint.

- **Cloudflare Worker**: The `frontend/public/_worker.js` script is modified to construct the correct `PATH_INFO`-based URLs, inserting `/index.php/` into the path for all API requests.

- **Vite Proxy**: The `frontend/vite.config.js` proxy is updated to rewrite paths to match the new routing scheme for a consistent local development experience.

- **Documentation**: The `README.md` is updated to reflect the new routing architecture and provides the correct, updated URLs for configuration (e.g., the Telegram webhook).

- **Cleanup**: The now-unnecessary `.htaccess` file has been removed from the backend directory.

This definitive fix ensures the application works correctly across different server environments by removing the dependency on `mod_rewrite`.