### PR TITLE
fix(backend): Prevent crash when .env is missing

### DIFF
--- a/backend/init.php
+++ b/backend/init.php
@@ -5,6 +5,11 @@ function load_env($path) {
     }
 
     $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    if ($lines === false) {
+        // Log an error if the .env file cannot be read, but don't cause a fatal error.
+        error_log("Warning: Could not read the .env file at {$path}. Environment variables not loaded.");
+        return;
+    }
     foreach ($lines as $line) {
         if (strpos(trim($line), '#') === 0) {
             continue;


### PR DESCRIPTION
The backend was crashing with a fatal PHP error if the .env file was missing or unreadable. This was happening in `init.php` because the `file()` function would return `false`, and the subsequent `foreach` loop on a boolean value would cause a crash.

This change makes the `load_env` function more robust by:
1. Checking if the `file()` call was successful.
2. If it fails, it now logs a warning using `error_log()` instead of crashing.

This ensures the application remains running and provides a clear diagnostic message in the server logs, which will help with debugging in production environments where the .env file might not be present.