### PR TITLE
feat: Implement bot-based user registration approval

### DIFF
--- a/backend/bootstrap.php
+++ b/backend/bootstrap.php
@@ -1,0 +1,46 @@
+<?php
+// backend/bootstrap.php
+
+/**
+ * Loads environment variables from a .env file into the application.
+ *
+ * This function reads a .env file, parses its contents, and loads the
+ * variables into PHP's environment using putenv(), $_ENV, and $_SERVER.
+ * It will not overwrite existing environment variables.
+ *
+ * @param string $path The path to the .env file.
+ */
+function load_env($path) {
+    if (!is_readable($path)) {
+        // Silently return if the file doesn't exist or isn't readable.
+        // The application will rely on server-level environment variables.
+        return;
+    }
+
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    if ($lines === false) {
+        return;
+    }
+
+    foreach ($lines as $line) {
+        // Skip comments
+        if (strpos(trim($line), '#') === 0) {
+            continue;
+        }
+
+        list($name, $value) = explode('=', $line, 2);
+        $name = trim($name);
+        $value = trim($value);
+
+        // Do not overwrite existing environment variables.
+        if (!array_key_exists($name, $_SERVER) && !array_key_exists($name, $_ENV)) {
+            putenv(sprintf('%s=%s', $name, $value));
+            $_ENV[$name] = $value;
+            $_SERVER[$name] = $value;
+        }
+    }
+}
+
+// Load the .env file from the backend directory.
+load_env(__DIR__ . '/.env');
+?>

--- a/backend/config.php
+++ b/backend/config.php
@@ -2,15 +2,20 @@
 // backend/config.php
 
 // --- Security ---
-// This secret must match the one in the Cloudflare Worker script.
-define('WORKER_SECRET', '816429fb-1649-4e48-9288-7629893311a6');
+// The secret for communicating with the Cloudflare Worker.
+define('WORKER_SECRET', getenv('WORKER_SECRET') ?: '816429fb-1649-4e48-9288-7629893311a6');
 
 // --- Database Credentials ---
-// Replace with your actual database connection details.
-define('DB_HOST', 'localhost');
-define('DB_USER', 'your_db_user');
-define('DB_PASS', 'your_db_password');
-define('DB_NAME', 'your_db_name');
+// These are loaded from the .env file via bootstrap.php.
+define('DB_HOST', getenv('DB_HOST') ?: 'localhost');
+define('DB_USER', getenv('DB_USER') ?: 'your_db_user');
+define('DB_PASS', getenv('DB_PASS') ?: 'your_db_password');
+define('DB_NAME', getenv('DB_NAME') ?: 'your_db_name');
+
+// --- Telegram Bot ---
+// Credentials for the administration bot.
+define('TELEGRAM_BOT_TOKEN', getenv('TELEGRAM_BOT_TOKEN'));
+define('TELEGRAM_ADMIN_ID', getenv('TELEGRAM_ADMIN_ID'));
 
 // --- File Uploads ---
 // The directory where email files and attachments will be stored.

--- a/backend/endpoints/register.php
+++ b/backend/endpoints/register.php
@@ -11,11 +11,17 @@ if (!$input || !isset($input['username']) || !isset($input['password'])) {
     send_json_response(['error' => 'Username and password are required.'], 400);
 }
 
-$username = trim($input['username']);
+// The 'username' from the form is treated as the user's email address.
+$email = trim($input['username']);
 $password = $input['password'];
 
-if (empty($username) || empty($password)) {
-    send_json_response(['error' => 'Username and password cannot be empty.'], 400);
+if (empty($email) || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    // Frontend expects 'username', so we message in that context, but validate as email.
+    send_json_response(['error' => 'A valid email address must be used as the username.'], 400);
+}
+
+if (empty($password)) {
+    send_json_response(['error' => 'Password cannot be empty.'], 400);
 }
 
 $conn = get_db_connection();
@@ -23,40 +29,72 @@ if (!$conn) {
     send_json_response(['error' => 'Database connection failed.'], 500);
 }
 
-// First, check if the username already exists.
-$stmt_check = $conn->prepare("SELECT username FROM users WHERE username = ?");
-if (!$stmt_check) {
-    error_log("DB prepare statement failed (check): " . $conn->error);
+// --- Step 1: Check if the email is in the allowed list ---
+$stmt_allowed = $conn->prepare("SELECT id FROM allowed_emails WHERE email = ?");
+if (!$stmt_allowed) {
+    error_log("DB prepare statement failed (check allowed): " . $conn->error);
     send_json_response(['error' => 'Database query failed.'], 500);
 }
-$stmt_check->bind_param("s", $username);
+$stmt_allowed->bind_param("s", $email);
+$stmt_allowed->execute();
+$stmt_allowed->store_result();
+
+if ($stmt_allowed->num_rows === 0) {
+    $stmt_allowed->close();
+    $conn->close();
+    // Email is not on the allowed list.
+    send_json_response(['error' => '此邮箱未被授权注册，请联系管理员。'], 403); // 403 Forbidden
+}
+$stmt_allowed->close();
+
+// --- Step 2: Check if the user is already registered in the 'users' table ---
+$stmt_check = $conn->prepare("SELECT username FROM users WHERE username = ?");
+if (!$stmt_check) {
+    error_log("DB prepare statement failed (check users): " . $conn->error);
+    send_json_response(['error' => 'Database query failed.'], 500);
+}
+$stmt_check->bind_param("s", $email); // We use email as the username
 $stmt_check->execute();
 $stmt_check->store_result();
 
 if ($stmt_check->num_rows > 0) {
+    $stmt_check->close();
+    $conn->close();
     send_json_response(['error' => 'Username already exists.'], 409); // 409 Conflict
 }
 $stmt_check->close();
 
-// Hash the password for secure storage.
-$hashed_password = password_hash($password, PASSWORD_DEFAULT);
+// --- Step 3: Register the user within a transaction ---
+$conn->begin_transaction();
 
-// Insert the new user into the database.
-$stmt_insert = $conn->prepare("INSERT INTO users (username, password) VALUES (?, ?)");
-if (!$stmt_insert) {
-    error_log("DB prepare statement failed (insert): " . $conn->error);
-    send_json_response(['error' => 'Database operation failed.'], 500);
+try {
+    // Insert the new user. Assume 'username' and 'email' columns exist.
+    $stmt_insert = $conn->prepare("INSERT INTO users (username, password, email) VALUES (?, ?, ?)");
+    if (!$stmt_insert) throw new Exception("DB prepare statement failed (insert user): " . $conn->error);
+
+    $hashed_password = password_hash($password, PASSWORD_DEFAULT);
+    $stmt_insert->bind_param("sss", $email, $hashed_password, $email);
+    if (!$stmt_insert->execute()) throw new Exception("DB execute failed (insert user): " . $stmt_insert->error);
+    $stmt_insert->close();
+
+    // Delete the email from the allowed list to prevent reuse.
+    $stmt_delete = $conn->prepare("DELETE FROM allowed_emails WHERE email = ?");
+    if (!$stmt_delete) throw new Exception("DB prepare statement failed (delete allowed): " . $conn->error);
+    $stmt_delete->bind_param("s", $email);
+    if (!$stmt_delete->execute()) throw new Exception("DB execute failed (delete allowed): " . $stmt_delete->error);
+    $stmt_delete->close();
+
+    // If all went well, commit the transaction.
+    $conn->commit();
+
+    send_json_response(['success' => true, 'message' => 'User registered successfully.'], 201);
+
+} catch (Exception $e) {
+    // Something went wrong, roll back the transaction.
+    $conn->rollback();
+    error_log($e->getMessage());
+    send_json_response(['error' => 'Failed to register user due to a server error.'], 500);
 }
 
-$stmt_insert->bind_param("ss", $username, $hashed_password);
-
-if ($stmt_insert->execute()) {
-    send_json_response(['success' => true, 'message' => 'User registered successfully.'], 201); // 201 Created
-} else {
-    error_log("DB execute failed (insert): " . $stmt_insert->error);
-    send_json_response(['error' => 'Failed to register user.'], 500);
-}
-
-$stmt_insert->close();
 $conn->close();
 ?>

--- a/backend/endpoints/telegram_webhook.php
+++ b/backend/endpoints/telegram_webhook.php
@@ -1,0 +1,76 @@
+<?php
+// backend/endpoints/telegram_webhook.php
+
+// --- Security Check: Ensure required constants are defined ---
+if (!defined('TELEGRAM_BOT_TOKEN') || !defined('TELEGRAM_ADMIN_ID')) {
+    // Log an error and exit silently. No response should be sent to Telegram.
+    error_log("Telegram bot token or admin ID is not configured.");
+    exit;
+}
+
+// 1. Get the incoming update from Telegram
+$update = json_decode(file_get_contents('php://input'), true);
+
+if (!$update || !isset($update['message']['text']) || !isset($update['message']['from']['id'])) {
+    // Not a valid message update, so we can ignore it.
+    exit;
+}
+
+$message = $update['message'];
+$chat_id = $message['chat']['id'];
+$user_id = $message['from']['id'];
+$text = trim($message['text']);
+
+// 2. --- Admin-Only Authorization ---
+// Only process commands from the configured admin user.
+if ((string)$user_id !== (string)TELEGRAM_ADMIN_ID) {
+    // Optional: could send a "not authorized" message, but it's better to stay silent.
+    exit;
+}
+
+// 3. --- Command Parsing and Handling ---
+if (strpos($text, '/add_email') === 0) {
+    $parts = explode(' ', $text, 2);
+    $email_to_add = trim($parts[1] ?? '');
+
+    if (empty($email_to_add) || !filter_var($email_to_add, FILTER_VALIDATE_EMAIL)) {
+        send_telegram_message($chat_id, "❌ Invalid format. Please use: `/add_email user@example.com`");
+        exit;
+    }
+
+    // 4. --- Database Interaction ---
+    $conn = get_db_connection();
+    if (!$conn) {
+        send_telegram_message($chat_id, "🚨 Error: Could not connect to the database.");
+        exit;
+    }
+
+    // Check if the email already exists to prevent duplicates.
+    $stmt_check = $conn->prepare("SELECT email FROM allowed_emails WHERE email = ?");
+    $stmt_check->bind_param("s", $email_to_add);
+    $stmt_check->execute();
+    $stmt_check->store_result();
+
+    if ($stmt_check->num_rows > 0) {
+        send_telegram_message($chat_id, "⚠️ This email `{$email_to_add}` is already on the allowed list.");
+        $stmt_check->close();
+        $conn->close();
+        exit;
+    }
+    $stmt_check->close();
+
+    // Insert the new email. Assumes an 'allowed_emails' table with an 'email' column.
+    $stmt_insert = $conn->prepare("INSERT INTO allowed_emails (email) VALUES (?)");
+    $stmt_insert->bind_param("s", $email_to_add);
+
+    if ($stmt_insert->execute()) {
+        send_telegram_message($chat_id, "✅ Success! The email `{$email_to_add}` has been added to the allowed list.");
+    } else {
+        error_log("Failed to insert allowed email: " . $stmt_insert->error);
+        send_telegram_message($chat_id, "🚨 Error: Could not add the email to the database.");
+    }
+
+    $stmt_insert->close();
+    $conn->close();
+}
+?>

--- a/backend/index.php
+++ b/backend/index.php
@@ -1,6 +1,9 @@
 <?php
 // backend/index.php
 
+// Bootstrap the application by loading environment variables and configuration.
+require_once __DIR__ . '/bootstrap.php';
+
 // --- CORS and Preflight Request Handling ---
 // A list of allowed origins for CORS.
 $allowed_origins = [

--- a/backend/lib/helpers.php
+++ b/backend/lib/helpers.php
@@ -32,4 +32,51 @@ function get_db_connection() {
 
     return $conn;
 }
+
+/**
+ * Sends a message to a Telegram chat.
+ *
+ * @param string|int $chat_id The ID of the chat to send the message to.
+ * @param string $message The text of the message to send.
+ * @return bool True on success, false on failure.
+ */
+function send_telegram_message($chat_id, $message) {
+    $bot_token = TELEGRAM_BOT_TOKEN;
+    if (empty($bot_token) || empty($chat_id)) {
+        return false;
+    }
+
+    $api_url = "https://api.telegram.org/bot{$bot_token}/sendMessage";
+
+    $payload = [
+        'chat_id' => $chat_id,
+        'text' => $message,
+        'parse_mode' => 'Markdown' // Optional: for formatting
+    ];
+
+    $options = [
+        'http' => [
+            'method'  => 'POST',
+            'header'  => "Content-type: application/json\r\n",
+            'content' => json_encode($payload),
+            'ignore_errors' => true // Allows reading the response body on failure
+        ]
+    ];
+
+    $context = stream_context_create($options);
+    $result = file_get_contents($api_url, false, $context);
+
+    if ($result === false) {
+        error_log("Telegram API request failed completely.");
+        return false;
+    }
+
+    $response_data = json_decode($result, true);
+    if (!$response_data['ok']) {
+        error_log("Telegram API Error: " . ($response_data['description'] ?? 'Unknown error'));
+        return false;
+    }
+
+    return true;
+}
 ?>

--- a/frontend/public/_worker.js
+++ b/frontend/public/_worker.js
@@ -11,7 +11,8 @@ export default {
       '/logout',
       '/register',
       '/is_user_registered',
-      '/email_upload'
+      '/email_upload',
+      '/telegram_webhook'
     ];
 
     // Check if the requested path is an API endpoint.


### PR DESCRIPTION
This commit introduces a new administration feature that restricts user registration to only those emails that have been pre-approved by an admin via a Telegram bot.

Key changes:
- **.env Loading:** Re-introduced a mechanism to load environment variables from a `.env` file using a new `bootstrap.php` file. The `config.php` has been updated to use `getenv()` to fetch credentials.
- **Telegram Bot Webhook:**
  - Added a new `/telegram_webhook` endpoint to the backend.
  - This endpoint listens for an `/add_email <email>` command from a whitelisted Telegram Admin ID (configured in `.env`).
  - Upon receiving a valid command, the bot adds the specified email to a new `allowed_emails` table in the database.
- **Restricted Registration Logic:**
  - The `/register` endpoint has been updated to first check if the user's email exists in the `allowed_emails` table.
  - If the email is not on the list, registration is blocked with a "Please contact the administrator" message.
  - If the email is on the list, the registration proceeds, and the email is then removed from the `allowed_emails` table to prevent reuse.
- **Cloudflare Worker Update:** The `/telegram_webhook` path has been added to the worker's proxy list to make it accessible to Telegram's servers.