### PR TITLE
fix(backend): Make router handle .php extensions gracefully

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -9,20 +9,16 @@ file_put_contents(__DIR__ . '/request.log', $log_message, FILE_APPEND);
 require_once __DIR__ . '/bootstrap.php';
 
 // --- CORS and Preflight Request Handling ---
-// A list of allowed origins for CORS.
 $allowed_origins = [
-    'http://localhost:5173',      // Vite dev server
-    'https://ss.wenxiuxiu.eu.org' // Production frontend
+    'http://localhost:5173',
+    'https://ss.wenxiuxiu.eu.org'
 ];
-
 if (isset($_SERVER['HTTP_ORIGIN']) && in_array($_SERVER['HTTP_ORIGIN'], $allowed_origins)) {
     header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
     header('Access-Control-Allow-Credentials: true');
     header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With');
     header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
 }
-
-// Handle preflight 'OPTIONS' requests and exit early.
 if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
     if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])) {
         header("HTTP/1.1 200 OK");
@@ -33,30 +29,32 @@ if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/lib/helpers.php';
 
-// Get the requested path from the server's request URI.
-// The RewriteRule in .htaccess ensures that all requests go here.
+// --- Flexible Routing ---
 $request_uri = $_SERVER['REQUEST_URI'];
-$base_path = '/backend'; // Adjust if your app is in a subdirectory
+$base_path = '/backend';
 
-// Remove the base path and query string from the request URI to get the endpoint path.
-$request_path = parse_url(str_replace($base_path, '', $request_uri), PHP_URL_PATH);
+// Remove the base path to isolate the endpoint part.
+$request_path = str_replace($base_path, '', $request_uri);
+// Remove any query string.
+$request_path = parse_url($request_path, PHP_URL_PATH);
+// Remove the .php extension if it exists to handle both clean and old URLs.
+$request_path = preg_replace('/\.php$/', '', $request_path);
 
-// Sanitize the path to prevent directory traversal attacks.
-// Allow only alphanumeric characters and underscores in the endpoint name.
+// Sanitize the path to prevent directory traversal and invalid characters.
 $endpoint = preg_replace('/[^a-zA-Z0-9_]/', '', trim($request_path, '/'));
 
-// Default to a 'not_found' endpoint if the requested path is empty.
 if (empty($endpoint)) {
+    // Handle root requests if necessary, otherwise default to not_found.
     $endpoint = 'not_found';
 }
 
-// Construct the path to the endpoint file.
 $endpoint_file = __DIR__ . '/endpoints/' . $endpoint . '.php';
 
-// If the endpoint file exists, include it. Otherwise, handle as a 404 Not Found error.
 if (file_exists($endpoint_file)) {
     require_once $endpoint_file;
 } else {
-    send_json_response(['error' => 'API endpoint not found.'], 404);
+    // Log the missing endpoint for debugging.
+    error_log("Endpoint not found for request: {$request_uri}. Resolved to: {$endpoint_file}");
+    send_json_response(['error' => "API endpoint '{$endpoint}' not found."], 404);
 }
 ?>


### PR DESCRIPTION
The server logs revealed that requests were still being made to URLs ending in `.php` (e.g., `/tg_webhook.php`), which the new clean-URL router was not handling, resulting in 502 errors.

This commit updates the main router in `backend/index.php` to be more flexible. It now automatically strips the `.php` extension from the request path. This allows the application to correctly handle both clean URLs (e.g., `/tg_webhook`) and legacy URLs (`/tg_webhook.php`) and route them to the same endpoint script.

This change ensures compatibility with the existing server configuration and should resolve the persistent 502 errors.