### PR TITLE
fix(backend): Add forced error logging for debugging

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -1,6 +1,13 @@
 <?php
 // backend/index.php
 
+// --- Force Error Logging for Debugging ---
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+ini_set('log_errors', 1);
+ini_set('error_log', __DIR__ . '/error.log');
+
 // --- Simple Request Logging for Debugging ---
 $log_message = date('[Y-m-d H:i:s]') . " " . $_SERVER['REQUEST_METHOD'] . " " . $_SERVER['REQUEST_URI'] . "\n";
 file_put_contents(__DIR__ . '/request.log', $log_message, FILE_APPEND);


### PR DESCRIPTION
To diagnose a persistent 502 error where the PHP application is crashing silently, this commit adds forced error logging to the main `index.php` file.

- `ini_set` is used to display all errors and log them to a new `backend/error.log` file.
- This will ensure that any fatal error that is causing the application to crash is captured, allowing for targeted debugging.

This is a debugging step to identify the root cause of the server failure.