### PR TITLE
fix(backend): Correct .htaccess to enforce routing through index.php

### DIFF
--- a/backend/.htaccess
+++ b/backend/.htaccess
@@ -1,7 +1,7 @@
 <IfModule mod_rewrite.c>
     RewriteEngine On
     RewriteBase /backend/
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
+    # Route all requests through index.php to ensure the application
+    # is always bootstrapped correctly.
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>


### PR DESCRIPTION
This commit provides the definitive fix for the persistent 502 Bad Gateway errors.

The root cause was identified from the server logs: requests for existing files (e.g., `/tg_webhook.php`) were being executed directly by the server instead of being routed through the main `index.php` file. This was happening because the previous `.htaccess` configuration included `RewriteCond %{REQUEST_FILENAME} !-f`, which prevented the rewrite rule from applying if a file existed at the requested path.

When endpoint files were executed directly, they would immediately crash with a fatal error because the application was not bootstrapped (i.e., `bootstrap.php`, `config.php`, and `helpers.php` were not loaded).

This commit fixes the issue by removing the file and directory existence conditions from the `.htaccess` file. Now, **all** requests are correctly and reliably routed through `index.php`, ensuring the application is always bootstrapped properly before any endpoint logic is executed. This is the standard implementation for a front-controller pattern and will resolve the 502 errors.