### PR TITLE
fix(backend): Revert to query-based routing for compatibility

### DIFF
--- a/backend/.htaccess
+++ b/backend/.htaccess
@@ -1,7 +1,0 @@
-<IfModule mod_rewrite.c>
-    RewriteEngine On
-    RewriteBase /backend/
-    # Route all requests through index.php to ensure the application
-    # is always bootstrapped correctly.
-    RewriteRule ^(.*)$ index.php [QSA,L]
-</IfModule>


### PR DESCRIPTION
This commit provides a definitive fix for the persistent 502 errors by reverting the application's routing mechanism to a more compatible query-based system.

The root cause of the errors was a server configuration that did not process the `.htaccess` file correctly. This caused requests for paths that matched a file on disk (e.g., `/tg_webhook.php`) to be executed directly, bypassing the main `index.php` router and its essential bootstrapping process, leading to fatal errors.

This commit resolves the issue by:
1.  **Deleting the `.htaccess` file** to remove the dependency on server-specific URL rewriting.
2.  **Updating `backend/index.php`** to use a standard query parameter (`?endpoint=...`) for routing. This is the most reliable method and works on any server configuration.
3.  **Updating the Cloudflare Worker** (`frontend/public/_worker.js`) to translate the clean URLs used by the frontend into the new query-parameter URLs that the backend now expects.

The frontend components continue to use clean URLs (e.g., `/get_numbers`), ensuring the frontend code remains clean, while the worker handles the translation. This synchronizes the entire application stack and resolves the underlying cause of the server errors.