### PR TITLE
fix(backend): Make all endpoints self-sufficient to fix 502 errors

### DIFF
--- a/backend/endpoints/check_session.php
+++ b/backend/endpoints/check_session.php
@@ -1,6 +1,11 @@
 <?php
 // backend/endpoints/check_session.php
 
+// Bootstrap the application
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
 // This endpoint is used to check if a user is currently logged in.
 // It must be called with credentials to access the session cookie.
 

--- a/backend/endpoints/email_upload.php
+++ b/backend/endpoints/email_upload.php
@@ -1,6 +1,11 @@
 <?php
 // backend/endpoints/email_upload.php
 
+// Bootstrap the application
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     send_json_response(['error' => 'Method not allowed.'], 405);
 }

--- a/backend/endpoints/get_numbers.php
+++ b/backend/endpoints/get_numbers.php
@@ -1,6 +1,11 @@
 <?php
 // backend/endpoints/get_numbers.php
 
+// Bootstrap the application
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
 if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     send_json_response(['error' => 'Method not allowed.'], 405);
 }

--- a/backend/endpoints/is_user_registered.php
+++ b/backend/endpoints/is_user_registered.php
@@ -1,6 +1,11 @@
 <?php
 // backend/endpoints/is_user_registered.php
 
+// Bootstrap the application
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
 if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     send_json_response(['error' => 'Method not allowed.'], 405);
 }

--- a/backend/endpoints/login.php
+++ b/backend/endpoints/login.php
@@ -1,6 +1,11 @@
 <?php
 // backend/endpoints/login.php
 
+// Bootstrap the application
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     send_json_response(['error' => 'Method not allowed.'], 405);
 }

--- a/backend/endpoints/logout.php
+++ b/backend/endpoints/logout.php
@@ -1,6 +1,11 @@
 <?php
 // backend/endpoints/logout.php
 
+// Bootstrap the application
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
 // This endpoint logs the user out by destroying their session.
 
 // Start the session to access and destroy it.

--- a/backend/endpoints/register.php
+++ b/backend/endpoints/register.php
@@ -1,6 +1,11 @@
 <?php
 // backend/endpoints/register.php
 
+// Bootstrap the application
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     send_json_response(['error' => 'Method not allowed.'], 405);
 }

--- a/backend/endpoints/tg_webhook.php
+++ b/backend/endpoints/tg_webhook.php
@@ -1,6 +1,11 @@
 <?php
 // backend/endpoints/tg_webhook.php
 
+// Bootstrap the application
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
 // --- Security Check: Ensure required constants are defined ---
 if (!defined('TELEGRAM_BOT_TOKEN') || !defined('TELEGRAM_ADMIN_ID')) {
     error_log("Telegram bot token or admin ID is not configured.");


### PR DESCRIPTION
This commit provides the definitive fix for the persistent 502 Bad Gateway errors by making every endpoint script runnable on its own.

The root cause of the issue was a server configuration that executed endpoint PHP files directly, bypassing the main `index.php` router. This caused the scripts to crash because they were missing the necessary application bootstrap (config, helpers, etc.).

This commit resolves the issue by adding the following lines to the top of every file in the `backend/endpoints/` directory:
```php
require_once __DIR__ . '/../bootstrap.php';
require_once __DIR__ . '/../config.php';
require_once __DIR__ . '/../lib/helpers.php';
```
This ensures that no matter how the server runs the endpoint, the application will always be correctly bootstrapped, preventing fatal errors. This robust approach guarantees compatibility with the user's server environment and resolves the underlying cause of the 502 errors.