### PR TITLE
feat(backend): Implement path-based routing

### DIFF
--- a/backend/.htaccess
+++ b/backend/.htaccess
@@ -1,0 +1,10 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    # Redirect Trailing Slashes If Not A Folder...
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^(.*)/$ /$1 [L,R=301]
+    # Handle Front Controller...
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ index.php [L]
+</IfModule>

--- a/backend/index.php
+++ b/backend/index.php
@@ -36,10 +36,20 @@ if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/lib/helpers.php';
 
-// --- Query-Based Routing ---
-// This is the most compatible routing method, expecting URLs like:
-// /backend/index.php?endpoint=get_numbers
-$endpoint = $_GET['endpoint'] ?? 'not_found';
+// --- Path-Based Routing ---
+// Handles clean URLs like /get_numbers, which are rewritten by .htaccess
+$base_path = dirname($_SERVER['SCRIPT_NAME']);
+$request_path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+// If the base path is not the root, remove it from the request path
+if ($base_path !== '/' && strpos($request_path, $base_path) === 0) {
+    $endpoint = substr($request_path, strlen($base_path));
+} else {
+    $endpoint = $request_path;
+}
+
+$endpoint = trim($endpoint, '/');
+
 
 // Sanitize the endpoint name to prevent directory traversal and invalid characters.
 $endpoint = basename($endpoint, '.php');


### PR DESCRIPTION
Refactor the backend routing mechanism to use clean, path-based URLs (e.g., /get_numbers) instead of the previous query-based system (e.g., index.php?endpoint=get_numbers).

- Add a .htaccess file to the backend directory to rewrite all relevant API requests to the index.php front controller.
- Update backend/index.php to parse the endpoint from the `REQUEST_URI` server variable, making it compatible with the new URL structure.
- The routing logic is now robust and correctly handles deployments in subdirectories by stripping the base path from the request URI.

This change modernizes the API, improves URL readability, and aligns the backend with the frontend's expectations, which already uses path-based fetch requests.