### PR TITLE
feat(telegram): Add keyboard menu to admin bot

### DIFF
--- a/backend/endpoints/tg_webhook.php
+++ b/backend/endpoints/tg_webhook.php
@@ -133,7 +133,11 @@ log_message("Admin check PASSED.");
 
 $keyboard = ['keyboard' => [[['text' => '🔑 授权新邮箱'], ['text' => '🗑 撤销授权']], [['text' => '👥 列出用户'], ['text' => '📋 列出授权列表']], [['text' => '🔍 查找用户'], ['text' => '📊 系统状态']]], 'resize_keyboard' => true];
 
-if (strpos($text, '/add_email') === 0 || strpos($text, '授权新邮箱') !== false) {
+if ($text === '/start') {
+    log_message("Entering command: /start");
+    $help_text = "🤖 *管理员机器人控制台*\n\n您好！请使用下方的键盘或直接发送命令来管理您的应用。";
+    send_telegram_message($chat_id, $help_text, $keyboard);
+} elseif (strpos($text, '/add_email') === 0 || strpos($text, '授权新邮箱') !== false) {
     log_message("Entering command: add_email");
     $conn = get_db_or_exit($chat_id, true);
     $email = parse_email_from_command($text);

--- a/backend/lib/helpers.php
+++ b/backend/lib/helpers.php
@@ -38,9 +38,10 @@ function get_db_connection() {
  *
  * @param string|int $chat_id The ID of the chat to send the message to.
  * @param string $message The text of the message to send.
+ * @param array|null $reply_markup Optional. An array representing the custom keyboard.
  * @return bool True on success, false on failure.
  */
-function send_telegram_message($chat_id, $message) {
+function send_telegram_message($chat_id, $message, $reply_markup = null) {
     $bot_token = TELEGRAM_BOT_TOKEN;
     if (empty($bot_token) || empty($chat_id)) {
         return false;
@@ -53,6 +54,11 @@ function send_telegram_message($chat_id, $message) {
         'text' => $message,
         'parse_mode' => 'Markdown' // Optional: for formatting
     ];
+
+    // Add the keyboard (reply_markup) to the payload if it's provided
+    if ($reply_markup) {
+        $payload['reply_markup'] = $reply_markup;
+    }
 
     $options = [
         'http' => [


### PR DESCRIPTION
This commit introduces a keyboard menu to the Telegram admin bot to improve usability.

- Modified the `send_telegram_message` helper in `lib/helpers.php` to support an optional `reply_markup` parameter, allowing keyboards to be sent with messages.
- Added a `/start` command handler in the `tg_webhook.php` endpoint. When an admin sends `/start`, the bot now responds with a welcome message and a keyboard menu of available commands.
- This addresses the issue where the keyboard was not reliably appearing for the admin user.