### PR TITLE
Fix: Correctly send keyboard markup in Telegram messages

### DIFF
--- a/backend/lib/helpers.php
+++ b/backend/lib/helpers.php
@@ -40,7 +40,7 @@ function get_db_connection() {
  * @param string $message The text of the message to send.
  * @return bool True on success, false on failure.
  */
-function send_telegram_message($chat_id, $message) {
+function send_telegram_message($chat_id, $message, $reply_markup = null) {
     $bot_token = TELEGRAM_BOT_TOKEN;
     if (empty($bot_token) || empty($chat_id)) {
         return false;
@@ -51,8 +51,12 @@ function send_telegram_message($chat_id, $message) {
     $payload = [
         'chat_id' => $chat_id,
         'text' => $message,
-        'parse_mode' => 'Markdown' // Optional: for formatting
+        'parse_mode' => 'Markdown'
     ];
+
+    if ($reply_markup) {
+        $payload['reply_markup'] = $reply_markup;
+    }
 
     $options = [
         'http' => [


### PR DESCRIPTION
The Telegram bot was unresponsive and the main keyboard menu was not appearing for the admin.

This was caused by the `send_telegram_message` helper function not properly handling the `reply_markup` parameter, which is required to send custom keyboards. The function signature has been updated to accept an optional `$reply_markup` argument, and the payload sent to the Telegram API now includes this data if it is provided.

This change, combined with the existing correct call in `tg_webhook.php` for the `/start` command, resolves the issue and ensures the admin keyboard is displayed as intended.