### PR TITLE
This commit fixes a fatal PHP error in `backend/bootstrap.php`.

### DIFF
--- a/backend/bootstrap.php
+++ b/backend/bootstrap.php
@@ -47,7 +47,6 @@ function load_env($path) {
             $_SERVER[$name] = $value;
         }
     }
-}
 
     // --- DEBUGGING: Log all found variables ---
     $found_vars = [];


### PR DESCRIPTION
A misplaced closing curly brace `}` was introduced during the addition of debugging code. This syntax error caused the script to terminate prematurely, making the entire bot unresponsive.

This hotfix moves the debugging code block to its correct position within the `load_env` function and removes the erroneous brace, restoring the bot's functionality.