### PR TITLE
This commit fixes a '405 Method Not Allowed' error that occurred duri…

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -166,6 +166,7 @@ export default {
     const apiRoutes = [
       '/check_session',
       '/login',
+      '/register', // <-- 添加缺失的注册路由
       '/get_numbers',
       '/is_user_registered',
       '/email_upload',


### PR DESCRIPTION
…ng user registration.

The root cause was that the Cloudflare Worker script (`worker/worker.js`) did not include `/register` in its list of recognized API routes (`apiRoutes`). As a result, POST requests to the registration endpoint were not being forwarded to the backend PHP server and were instead being incorrectly handled as requests for static assets.

This fix adds `/register` to the `apiRoutes` array, ensuring that registration requests are correctly proxied to the backend.