### PR TITLE
This commit fixes a fatal error that was causing the backend to crash…

### DIFF
--- a/backend/config.php
+++ b/backend/config.php
@@ -1,18 +1,8 @@
 <?php
 // backend/config.php
 
-// Include Composer's autoloader
-require_once __DIR__ . '/vendor/autoload.php';
-
-// Load environment variables from .env file
-try {
-    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
-    $dotenv->load();
-} catch (\Dotenv\Exception\InvalidPathException $e) {
-    // This error is expected if .env file is not found. 
-    // In a production environment, variables should be set directly.
-    error_log('.env file not found at path: ' . $e->getPath() . '. This is not an error if environment variables are set on the server.');
-}
+// Note: Composer and Dotenv are no longer used.
+// Environment variables are loaded manually by bootstrap.php.
 
 // --- Environment Variable Validation ---
 // On shared hosting, these might be set in the control panel. On a VPS, they are system-wide.


### PR DESCRIPTION
… on any API call that included `config.php`, most notably `/register`.

The root cause was a `require_once` call for `vendor/autoload.php` at the top of `config.php`. This file was intentionally deleted in a previous refactoring to remove the Composer dependency, but this require statement was missed.

This commit removes the erroneous `require_once` and the related `Dotenv` loading logic, as environment variables are now handled manually by `bootstrap.php`. This resolves the fatal error and restores functionality to the backend.