### PR TITLE
This commit provides a two-pronged final fix for a recurring 'Fatal e…

### DIFF
--- a/backend/endpoints/tg_webhook.php
+++ b/backend/endpoints/tg_webhook.php
@@ -46,7 +46,10 @@ function parse_email_from_command($command_text) {
 
 // --- BRANCH 1: Process Channel Posts for Lottery Results ---
 if (isset($update['channel_post'])) {
-    log_message("Entering Branch 1: Channel Post.");
+    // --- Enhanced Debugging: Log that a channel post was received ---
+    log_message("--- CHANNEL POST RECEIVED ---");
+    log_message("Full Post Data: " . json_encode($update['channel_post'], JSON_UNESCAPED_UNICODE));
+
     $channel_id = $update['channel_post']['chat']['id'];
     $post_text = $update['channel_post']['text'] ?? '';
 


### PR DESCRIPTION
…rror' issue.

1.  **Robustness in `get_numbers.php`**: The script now performs a preliminary check to see if the `lottery_results` table is empty. If it is, the script immediately returns a valid, empty JSON response, avoiding the main SQL query altogether. This prevents potential fatal errors on certain database versions when the query runs against an empty table.

2.  **Enhanced Logging in `tg_webhook.php`**: Added explicit, high-visibility logging at the very beginning of the channel post handling block. This will definitively confirm whether the webhook is receiving posts from the Telegram channel, which is crucial for diagnosing the data flow.

This combined approach should either resolve the issue directly or provide the final diagnostic information needed to pinpoint the root cause.