### PR TITLE
This commit updates the styling of the lottery page to allow the resu…

### DIFF
--- a/frontend/src/pages/LotteryPage.css
+++ b/frontend/src/pages/LotteryPage.css
@@ -5,7 +5,7 @@
   flex-direction: column;
   gap: var(--spacing-6); /* Space between banners */
   width: 100%;
-  max-width: 900px;
+  /* max-width: 900px; */ /* Removed to allow full width */
   margin: 0 auto;
 }
 


### PR DESCRIPTION
…lt banners to occupy the full width of the screen.

- In `frontend/src/pages/LotteryPage.css`, the `max-width` property has been removed from the `.lottery-container` class.

This change removes the previous 900px constraint, allowing the layout to expand horizontally, which provides a more immersive and modern look on wider screens.