### PR TITLE
This commit fixes a recurring and difficult-to-diagnose fatal error b…

### DIFF
--- a/backend/endpoints/check_session.php
+++ b/backend/endpoints/check_session.php
@@ -9,8 +9,7 @@ require_once __DIR__ . '/../lib/helpers.php';
 // This endpoint is used to check if a user is currently logged in.
 // It must be called with credentials to access the session cookie.
 
-// Start the session to access session variables.
-session_start();
+// Session is now started globally in index.php.
 
 if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
     // The user is logged in.

--- a/backend/endpoints/login.php
+++ b/backend/endpoints/login.php
@@ -66,8 +66,7 @@ if (password_verify($password, $user['password'])) {
         error_log("Failed to prepare statement for updating last_login_time: " . $conn->error);
     }
 
-    // Passwords match. Start a new, clean session.
-    session_start();
+    // Passwords match. Session is already started by index.php.
     // Regenerate session ID to prevent session fixation attacks.
     session_regenerate_id(true);
 

--- a/backend/endpoints/logout.php
+++ b/backend/endpoints/logout.php
@@ -8,13 +8,12 @@ require_once __DIR__ . '/../lib/helpers.php';
 
 // This endpoint logs the user out by destroying their session.
 
-// Start the session to access and destroy it.
-session_start();
+// Session is started globally in index.php.
 
 // Unset all session variables.
 $_SESSION = [];
 
-// Destroy the session cookie.
+// Destroy the session cookie by setting its expiration to the past.
 if (ini_get("session.use_cookies")) {
     $params = session_get_cookie_params();
     setcookie(session_name(), '', time() - 42000,
@@ -23,7 +22,7 @@ if (ini_get("session.use_cookies")) {
     );
 }
 
-// Finally, destroy the session.
+// Destroy the session data on the server.
 session_destroy();
 
 send_json_response(['success' => true, 'message' => 'Logged out successfully.']);

--- a/backend/index.php
+++ b/backend/index.php
@@ -12,6 +12,11 @@ ini_set('error_log', __DIR__ . '/error.log');
 $log_message = date('[Y-m-d H:i:s]') . " " . $_SERVER['REQUEST_METHOD'] . " " . $_SERVER['REQUEST_URI'] . "\n";
 file_put_contents(__DIR__ . '/request.log', $log_message, FILE_APPEND);
 
+// --- Global Session Start ---
+// Start the session at the very beginning of the request lifecycle.
+// This ensures $_SESSION is available for all endpoints.
+session_start();
+
 // Bootstrap the application by loading environment variables and configuration.
 require_once __DIR__ . '/bootstrap.php';
 


### PR DESCRIPTION
…y refactoring the application's session management strategy.

The root cause of the intermittent 'Fatal error' (which appeared as a JSON parsing error on the frontend) was the decentralized use of `session_start()` within individual endpoint files (`login.php`, `check_session.php`, etc.). In a single-entry-point architecture like this one, this approach is fragile and can lead to headers being sent before the session is started, causing a fatal crash.

This fix implements the industry-standard best practice:
- `session_start()` has been removed from all individual endpoint files.
- A single, global `session_start()` call has been added to the top of the main entry point, `backend/index.php`.

This ensures that the session is always started safely and correctly at the very beginning of the request lifecycle, completely eliminating this class of fatal errors and making the application significantly more stable and robust.