### PR TITLE
Fix: Resolve fatal error in Telegram message handling

### DIFF
--- a/backend/lib/telegram_utils.php
+++ b/backend/lib/telegram_utils.php
@@ -9,21 +9,26 @@
  * @param string $message The message text.
  * @return bool True on success, false on failure.
  */
-function send_telegram_message(string $bot_token, string $chat_id, string $message): bool
+function send_telegram_message(string $bot_token, string $chat_id, string $message, ?array $reply_markup = null): bool
 {
     $api_url = "https://api.telegram.org/bot{$bot_token}/sendMessage";
 
     $data = [
         'chat_id' => $chat_id,
         'text' => $message,
-        'parse_mode' => 'Markdown', // Optional: for formatting
+        'parse_mode' => 'Markdown',
     ];
+
+    // Add the keyboard to the request body if it's provided
+    if ($reply_markup) {
+        $data['reply_markup'] = json_encode($reply_markup);
+    }
 
     $options = [
         'http' => [
-            'header' => "Content-type: application/x-www-form-urlencoded\r\n",
+            'header' => "Content-type: application/json\r\n",
             'method' => 'POST',
-            'content' => http_build_query($data),
+            'content' => json_encode($data),
             'timeout' => 10, // 10-second timeout
         ],
     ];


### PR DESCRIPTION
This commit fixes a fatal `ArgumentCountError` that was causing the Telegram bot to be unresponsive. The error occurred because the `send_telegram_message` function was called with an incorrect number of arguments when sending messages with interactive keyboards.

- The function signature of `send_telegram_message` in `lib/telegram_utils.php` has been updated to correctly handle an optional `reply_markup` parameter.
- The function now sends the request payload as `application/json` to properly support the `reply_markup` field.
- All call sites for this function in `endpoints/tg_webhook.php` have been verified to match the new signature.

This change ensures that messages with and without keyboards can be sent without causing the script to crash, restoring the bot's functionality.