### PR TITLE
Fix: Resolve fatal error in check_session endpoint

### DIFF
--- a/backend/endpoints/check_session.php
+++ b/backend/endpoints/check_session.php
@@ -6,7 +6,19 @@ session_start();
 // Bootstrap the application
 require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../config.php';
-require_once __DIR__ . '/../lib/helpers.php';
+
+/**
+ * Sends a JSON response with the correct headers.
+ *
+ * @param array $data The data to encode as JSON.
+ * @param int $status_code The HTTP status code to send.
+ */
+function send_json_response(array $data, int $status_code = 200): void {
+    header('Content-Type: application/json');
+    http_response_code($status_code);
+    echo json_encode($data);
+    exit;
+}
 
 if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
     // The user is logged in.


### PR DESCRIPTION
This commit fixes a fatal error in the `check_session.php` script that was causing a JSON parsing failure on the frontend.

The script was attempting to include `backend/lib/helpers.php`, a file that no longer exists after previous refactoring. This generated a PHP warning, which corrupted the JSON response and caused the frontend application to fail when checking the user's session status.

The fix involves removing the incorrect `require_once` statement and defining the necessary `send_json_response` function directly within the `check_session.php` script. This resolves the error and ensures a clean JSON response is always sent to the frontend.