### PR TITLE
This is a hotfix to correct the file path logic for loading the `.env…

### DIFF
--- a/backend/bootstrap.php
+++ b/backend/bootstrap.php
@@ -4,8 +4,13 @@
 // Load helper functions, including our custom environment loader
 require_once __DIR__ . '/lib/helpers.php';
 
-// Load environment variables from .env file
-load_env(__DIR__ . '/../.env');
+// Define the project root as the parent directory of 'backend'
+if (!defined('PROJECT_ROOT')) {
+    define('PROJECT_ROOT', dirname(__DIR__));
+}
+
+// Load environment variables from the .env file at the project root
+load_env(PROJECT_ROOT . '/.env');
 
 // --- Global Database Connection ---
 

--- a/backend/set_telegram_webhook.php
+++ b/backend/set_telegram_webhook.php
@@ -7,8 +7,11 @@
 // 1. Load only the necessary helper for environment variables.
 require_once __DIR__ . '/lib/helpers.php';
 
-// 2. Load environment variables from the .env file in the project root.
-$dotenv_path = __DIR__ . '/../.env';
+// 2. Define the project root and load the .env file.
+if (!defined('PROJECT_ROOT')) {
+    define('PROJECT_ROOT', dirname(__DIR__));
+}
+$dotenv_path = PROJECT_ROOT . '/.env';
 if (file_exists($dotenv_path)) {
     load_env($dotenv_path);
 } else {


### PR DESCRIPTION
…` file.

The previous implementation used a relative path (`__DIR__ . '/../.env'`) which was not robust and failed when scripts were executed from different working directories, causing fatal 'file not found' errors.

This commit resolves the issue by:
1.  Defining a `PROJECT_ROOT` constant in both `backend/bootstrap.php` and `backend/set_telegram_webhook.php`.
2.  Using this constant to build a reliable, absolute path to the `.env` file.

This ensures that the application and all related scripts can consistently find and load the necessary environment variables.